### PR TITLE
COR-508 Enhance dockerfile with multi-stage builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,8 @@ certs/*
 
 generated.csv
 
+# Apple
 .DS_Store
+
+/coverage
+/reports

--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,45 @@ image: prerequisites
 	DOCKER_BUILDKIT=1 docker build -f ./build/package/app.Dockerfile -t core .
 
 .PHONY: up
+## Launches the docker-compose dependency stack
 up: prerequisites
 	@$(COMPOSE) -f deploy/docker-compose.yaml up
 
 .PHONY: down
+## Stops the docker-compose dependency stack
 down: prerequisites
 	@$(COMPOSE) -f deploy/docker-compose.yaml down
 
+.PHONY: .dev-image
+## Builds the development image
+.dev-image:
+	@DOCKER_BUILDKIT=1 docker build -f ./build/package/app.Dockerfile -t core-dev --target=dev --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g) .
+
+.PHONY: coverage
+## Runs the tests and generates a coverage report
+coverage: .dev-image
+	@mkdir -p ./reports
+	docker run --rm -it -v $(shell pwd)/reports:/app/reports core-dev coverage
+
 .PHONY: test
-test:
-	@go test ./...
+## Runs the tests
+test: .dev-image
+	docker run --rm -it -v $(shell pwd)/reports:/app/reports core-dev test
 
 .PHONY: proxy
+## Runs the envoy proxy
 proxy: prerequisites
 	@envoy -c deploy/envoy.yaml
 
 .PHONY: serve
-serve: prerequisites
+## Runs the development server
+serve:
 	@go run . serve --listen-address=:8080 --db-driver=postgres --db-dsn=postgres://postgres:postgres@localhost:5432/core?sslmode=disable --log-level=debug
+
+.DEFAULT_GOAL := show-help
+# See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
+.PHONY: show-help
+show-help:
+	@echo "$$(tput bold)Available rules:$$(tput sgr0)";echo;sed -ne"/^## /{h;s/.*//;:d" -e"H;n;s/^## //;td" -e"s/:.*//;G;s/\\n## /---/;s/\\n/ /g;p;}" ${MAKEFILE_LIST}|LC_ALL='C' sort -f|awk -F --- -v n=$$(tput cols) -v i=19 -v a="$$(tput setaf 6)" -v z="$$(tput sgr0)" '{printf"%s%*s%s ",a,-i,$$1,z;m=split($$2,w," ");l=n-i;for(j=1;j<=m;j++){l-=length(w[j])+1;if(l<= 0){l=n-i-length(w[j])-1;printf"\n%*s ",-i," ";}printf"%s ",w[j];}printf"\n";}'|more $(shell test $(shell uname) == Darwin && echo '-Xr')
+
+

--- a/build/package/app.Dockerfile
+++ b/build/package/app.Dockerfile
@@ -1,9 +1,35 @@
-FROM golang:1.18 as builder
+FROM golang:1.19 as base
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64 \
+    GOCACHE=/tmp/.cache
+ARG uid=1000
+ARG gid=1000
+RUN groupadd -g ${GROUP_ID} core || echo "Group already exists"
+RUN useradd -l -m -d /home/app -u ${USER_ID} -g ${GROUP_ID} core || echo "User already exists"
+RUN mkdir /out && chown ${uid}:${gid} /out
+USER ${uid}:${gid}
 WORKDIR /app
 COPY go.mod ./
 COPY go.sum ./
-RUN go mod download
+RUN go mod download && \
+    go install github.com/jstemmer/go-junit-report/v2@latest && \
+    go install github.com/axw/gocov/gocov@latest && \
+    go install github.com/AlekSi/gocov-xml@latest
 COPY . .
-RUN mkdir /out && go build -o /out/app --tags fts5 && chmod +x /out/app && rm -rf /app
+
+FROM base as dev
+ENTRYPOINT ["/app/scripts/docker-dev-entrypoint.sh"]
+
+FROM base as builder
+RUN go build -ldflags '-w -s' -o /out/core --tags fts5 && chmod +x /out/core
 WORKDIR /out
 ENTRYPOINT ["/out/app"]
+
+FROM gcr.io/distroless/base
+WORKDIR /
+COPY --from=builder /out/core /app/core
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/app/core"]

--- a/build/package/app.Dockerfile.dockerignore
+++ b/build/package/app.Dockerfile.dockerignore
@@ -1,3 +1,6 @@
 *.sqlite
 build
 Makefile
+deploy
+coverage
+reports

--- a/scripts/docker-dev-coverage.sh
+++ b/scripts/docker-dev-coverage.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# It will be available in the "dev" target of the Dockerfile
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+ROOT_DIR=$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)
+OUTPUT_DIR="${ROOT_DIR}/reports"
+
+case "$1" in
+"--output|-o")
+  echo "Output directory: $2"
+  OUTPUT_DIR="$2"
+  shift 2
+  ;;
+esac
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Running tests..."
+mkdir -p "${OUTPUT_DIR}"
+go test ./...
+go test ./... -coverpkg=./... -v -coverprofile="${OUTPUT_DIR}/coverage.txt" -covermode count 2>&1 | go-junit-report >"${OUTPUT_DIR}/report.xml"
+rc=${PIPESTATUS[0]}
+
+echo "Generating coverage report..."
+gocov convert "${OUTPUT_DIR}/coverage.txt" >"${OUTPUT_DIR}/coverage.json"
+gocov-xml <"${OUTPUT_DIR}/coverage.json" >"${OUTPUT_DIR}/coverage.xml"
+go tool cover -html="${OUTPUT_DIR}/coverage.txt" -o "${OUTPUT_DIR}/coverage.html"
+
+if [ "$rc" -ne 0 ]; then
+  echo "Tests failed"
+  exit "$rc"
+else
+  echo "Tests passed"
+fi

--- a/scripts/docker-dev-entrypoint.sh
+++ b/scripts/docker-dev-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is used as the entrypoint for the core "dev" container.
+# For now, only the "coverage" target is supported, but more targets
+# related to development can be added in the future.
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+case "$1" in
+"coverage")
+  shift
+  "${SCRIPT_DIR}"/docker-dev-coverage.sh "$@"
+  ;;
+"test")
+  shift
+  "${SCRIPT_DIR}"/docker-dev-tests.sh "$@"
+  ;;
+esac

--- a/scripts/docker-dev-tests.sh
+++ b/scripts/docker-dev-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+echo "Running tests..."
+go test ./...


### PR DESCRIPTION
Setting up the cicd pipelines will require a multi-stage build. Why: 
The first stage is based off a large golang:1.19 base image with a lot of libraries installed. We can use this "stage" as the "devel" stage, which contains tooling for testing, building, etc. 
But we don't want to ship a large container image with unnecessary stuff.  That's why the last "final" stage is a "distroless" container, a very lean container image with almost nothing on it. It's more secure, more lightweight. We simply copy the built executable from the first stage onto that final stage. 
The pipeline can still use the "devel" stage to launch tests from the built container image itself. 