### PR TITLE
Cor 558 filter all queries on country

### DIFF
--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -377,7 +377,7 @@ func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx,
 		if err != nil {
 			l.Error("failed to get rows affected", zap.Error(err))
 			return err
-		} else if rowsAffected != int64(len(ids)) {
+		} else if rowsAffected != int64(len(idsInBatch)) {
 			l.Error("failed to delete all individuals", zap.Int64("rows_affected", rowsAffected))
 			return fmt.Errorf("failed to delete all individuals")
 		}

--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/lib/pq"
 	"github.com/nrc-no/notcore/internal/api"
 	"github.com/nrc-no/notcore/internal/containers"
 	"github.com/nrc-no/notcore/internal/logging"
@@ -23,7 +22,7 @@ type IndividualRepo interface {
 	Put(ctx context.Context, individual *api.Individual, fields []string) (*api.Individual, error)
 	PutMany(ctx context.Context, individuals []*api.Individual, fields []string) ([]*api.Individual, error)
 	SoftDelete(ctx context.Context, id string) error
-	SoftDeleteMany(ctx context.Context, ids []string, countryId string) error
+	SoftDeleteMany(ctx context.Context, ids []string) error
 }
 
 type individualRepo struct {
@@ -387,29 +386,6 @@ func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx,
 	}); err != nil {
 		return err
 	}
-	return nil
-}
-
-func (i individualRepo) SoftDeleteMany(ctx context.Context, ids []string, countryId string) error {
-	_, err := doInTransaction(ctx, i.db, func(ctx context.Context, tx *sqlx.Tx) (interface{}, error) {
-		err := i.softDeleteManyInternal(ctx, tx, ids, countryId)
-		return nil, err
-	})
-	return err
-}
-
-func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx, ids []string, countryId string) error {
-	l := logging.NewLogger(ctx).With(zap.Strings("individual_ids", ids))
-	l.Debug("deleting individuals")
-
-	const query = "UPDATE individuals SET deleted_at = $1 WHERE id = ANY($2) and deleted_at IS NULL and country_id = $3"
-	var args = []interface{}{time.Now().UTC(), pq.Array(ids), countryId}
-
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		l.Error("failed to delete individuals", zap.Error(err))
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -377,7 +377,7 @@ func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx,
 		if err != nil {
 			l.Error("failed to get rows affected", zap.Error(err))
 			return err
-		} else if rowsAffected != int64(len(idsInBatch)) {
+		} else if rowsAffected != int64(len(ids)) {
 			l.Error("failed to delete all individuals", zap.Int64("rows_affected", rowsAffected))
 			return fmt.Errorf("failed to delete all individuals")
 		}
@@ -386,6 +386,7 @@ func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx,
 	}); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -19,7 +19,6 @@ import (
 type IndividualRepo interface {
 	GetAll(ctx context.Context, options api.GetAllOptions) ([]*api.Individual, error)
 	GetByID(ctx context.Context, id string) (*api.Individual, error)
-	ListByID(ctx context.Context, ids []string) ([]*api.Individual, error)
 	Put(ctx context.Context, individual *api.Individual, fields []string) (*api.Individual, error)
 	PutMany(ctx context.Context, individuals []*api.Individual, fields []string) ([]*api.Individual, error)
 	SoftDelete(ctx context.Context, id string) error
@@ -228,33 +227,6 @@ func (i individualRepo) getByIdInternal(ctx context.Context, tx *sqlx.Tx, id str
 		return nil, err
 	}
 	return &ret, nil
-}
-
-func (i individualRepo) ListByID(ctx context.Context, ids []string) ([]*api.Individual, error) {
-	ret, err := doInTransaction(ctx, i.db, func(ctx context.Context, tx *sqlx.Tx) (interface{}, error) {
-		return i.listByIDInternal(ctx, tx, ids)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return ret.([]*api.Individual), nil
-}
-
-func (i individualRepo) listByIDInternal(ctx context.Context, tx *sqlx.Tx, ids []string) ([]*api.Individual, error) {
-	l := logging.NewLogger(ctx)
-	l.Debug("getting individuals by id")
-	var ret []*api.Individual
-	if len(ids) == 0 {
-		return ret, nil
-	}
-
-	const query = "SELECT * FROM individuals WHERE id IN ($1) and deleted_at IS NULL"
-	var args = []interface{}{pq.Array(ids)}
-	err := tx.SelectContext(ctx, &ret, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
 }
 
 func (i individualRepo) PutMany(ctx context.Context, individuals []*api.Individual, fields []string) ([]*api.Individual, error) {

--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -312,7 +312,7 @@ func (i individualRepo) putManyInternal(ctx context.Context, tx *sqlx.Tx, indivi
 		b.WriteString(" ON CONFLICT (id) DO UPDATE SET ")
 		isFirst := true
 		for _, field := range fields {
-			if field == "id" {
+			if field == "id" || field == "country_id" {
 				continue
 			}
 			if !isFirst {

--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 	"github.com/nrc-no/notcore/internal/api"
 	"github.com/nrc-no/notcore/internal/containers"
 	"github.com/nrc-no/notcore/internal/logging"
@@ -386,6 +387,29 @@ func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx,
 	}); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (i individualRepo) SoftDeleteMany(ctx context.Context, ids []string) error {
+	_, err := doInTransaction(ctx, i.db, func(ctx context.Context, tx *sqlx.Tx) (interface{}, error) {
+		err := i.softDeleteManyInternal(ctx, tx, ids)
+		return nil, err
+	})
+	return err
+}
+
+func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx, ids []string) error {
+	l := logging.NewLogger(ctx).With(zap.Strings("individual_ids", ids))
+	l.Debug("deleting individuals")
+
+	const query = "UPDATE individuals SET deleted_at = $1 WHERE id = ANY($2) and deleted_at IS NULL"
+	var args = []interface{}{time.Now().UTC(), pq.Array(ids)}
+
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		l.Error("failed to delete individuals", zap.Error(err))
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -23,7 +23,7 @@ type IndividualRepo interface {
 	Put(ctx context.Context, individual *api.Individual, fields []string) (*api.Individual, error)
 	PutMany(ctx context.Context, individuals []*api.Individual, fields []string) ([]*api.Individual, error)
 	SoftDelete(ctx context.Context, id string) error
-	SoftDeleteMany(ctx context.Context, ids []string) error
+	SoftDeleteMany(ctx context.Context, ids []string, countryId string) error
 }
 
 type individualRepo struct {
@@ -390,20 +390,20 @@ func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx,
 	return nil
 }
 
-func (i individualRepo) SoftDeleteMany(ctx context.Context, ids []string) error {
+func (i individualRepo) SoftDeleteMany(ctx context.Context, ids []string, countryId string) error {
 	_, err := doInTransaction(ctx, i.db, func(ctx context.Context, tx *sqlx.Tx) (interface{}, error) {
-		err := i.softDeleteManyInternal(ctx, tx, ids)
+		err := i.softDeleteManyInternal(ctx, tx, ids, countryId)
 		return nil, err
 	})
 	return err
 }
 
-func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx, ids []string) error {
+func (i individualRepo) softDeleteManyInternal(ctx context.Context, tx *sqlx.Tx, ids []string, countryId string) error {
 	l := logging.NewLogger(ctx).With(zap.Strings("individual_ids", ids))
 	l.Debug("deleting individuals")
 
-	const query = "UPDATE individuals SET deleted_at = $1 WHERE id = ANY($2) and deleted_at IS NULL"
-	var args = []interface{}{time.Now().UTC(), pq.Array(ids)}
+	const query = "UPDATE individuals SET deleted_at = $1 WHERE id = ANY($2) and deleted_at IS NULL and country_id = $3"
+	var args = []interface{}{time.Now().UTC(), pq.Array(ids), countryId}
 
 	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 		l.Error("failed to delete individuals", zap.Error(err))

--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -19,6 +19,7 @@ import (
 type IndividualRepo interface {
 	GetAll(ctx context.Context, options api.GetAllOptions) ([]*api.Individual, error)
 	GetByID(ctx context.Context, id string) (*api.Individual, error)
+	ListByID(ctx context.Context, ids []string) ([]*api.Individual, error)
 	Put(ctx context.Context, individual *api.Individual, fields []string) (*api.Individual, error)
 	PutMany(ctx context.Context, individuals []*api.Individual, fields []string) ([]*api.Individual, error)
 	SoftDelete(ctx context.Context, id string) error
@@ -227,6 +228,33 @@ func (i individualRepo) getByIdInternal(ctx context.Context, tx *sqlx.Tx, id str
 		return nil, err
 	}
 	return &ret, nil
+}
+
+func (i individualRepo) ListByID(ctx context.Context, ids []string) ([]*api.Individual, error) {
+	ret, err := doInTransaction(ctx, i.db, func(ctx context.Context, tx *sqlx.Tx) (interface{}, error) {
+		return i.listByIDInternal(ctx, tx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret.([]*api.Individual), nil
+}
+
+func (i individualRepo) listByIDInternal(ctx context.Context, tx *sqlx.Tx, ids []string) ([]*api.Individual, error) {
+	l := logging.NewLogger(ctx)
+	l.Debug("getting individuals by id")
+	var ret []*api.Individual
+	if len(ids) == 0 {
+		return ret, nil
+	}
+
+	const query = "SELECT * FROM individuals WHERE id IN ($1) and deleted_at IS NULL"
+	var args = []interface{}{pq.Array(ids)}
+	err := tx.SelectContext(ctx, &ret, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
 }
 
 func (i individualRepo) PutMany(ctx context.Context, individuals []*api.Individual, fields []string) ([]*api.Individual, error) {

--- a/internal/handlers/individual.go
+++ b/internal/handlers/individual.go
@@ -47,6 +47,14 @@ func HandleIndividual(templates map[string]*template.Template, repo db.Individua
 			return
 		}
 
+		// Get the currently selected Country ID
+		selectedCountryID, err := utils.GetSelectedCountryID(ctx)
+		if err != nil {
+			l.Error("failed to get selected country id", zap.Error(err))
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
 		if !isNew {
 			if individual, err = repo.GetByID(ctx, individualId); err != nil {
 				l.Error("failed to get individual", zap.Error(err))
@@ -54,18 +62,15 @@ func HandleIndividual(templates map[string]*template.Template, repo db.Individua
 				render()
 				return
 			}
+
+			if individual.CountryID != selectedCountryID {
+				l.Error("individual does not belong to selected country", zap.Error(err))
+				http.Error(w, "individual does not belong to selected country", http.StatusForbidden)
+				return
+			}
 		}
 
 		individualForm = views.NewIndividualForm(individual)
-
-		// Get the currently selected Country ID
-		selectedCountryID, err := utils.GetSelectedCountryID(ctx)
-		if err != nil {
-			l.Error("failed to get selected country id", zap.Error(err))
-			err = apierrs.ErrorFrom(err)
-			render()
-			return
-		}
 
 		// Render the form if GET
 		if r.Method == http.MethodGet {

--- a/internal/handlers/individual.go
+++ b/internal/handlers/individual.go
@@ -64,8 +64,8 @@ func HandleIndividual(templates map[string]*template.Template, repo db.Individua
 			}
 
 			if individual.CountryID != selectedCountryID {
-				l.Error("individual does not belong to selected country", zap.Error(err))
-				http.Error(w, "individual does not belong to selected country", http.StatusForbidden)
+				l.Error("user trying to access individual with the wrong country id", zap.String("individual_id", individual.ID))
+				http.Error(w, fmt.Sprintf("individual not found: %v", individual.ID), http.StatusNotFound)
 				return
 			}
 		}

--- a/internal/handlers/individual.go
+++ b/internal/handlers/individual.go
@@ -64,7 +64,7 @@ func HandleIndividual(templates map[string]*template.Template, repo db.Individua
 			}
 
 			if individual.CountryID != selectedCountryID {
-				l.Error("user trying to access individual with the wrong country id", zap.String("individual_id", individual.ID))
+				l.Warn("user trying to access individual with the wrong country id", zap.String("individual_id", individual.ID))
 				http.Error(w, fmt.Sprintf("individual not found: %v", individual.ID), http.StatusNotFound)
 				return
 			}

--- a/internal/handlers/individual_delete.go
+++ b/internal/handlers/individual_delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nrc-no/notcore/internal/db"
 	"github.com/nrc-no/notcore/internal/logging"
+	"github.com/nrc-no/notcore/internal/utils"
 	"go.uber.org/zap"
 )
 
@@ -24,6 +25,13 @@ func HandleIndividualDelete(repo db.IndividualRepo) http.Handler {
 			l   = logging.NewLogger(ctx)
 		)
 
+		countryID, err := utils.GetSelectedCountryID(ctx)
+		if err != nil {
+			l.Error("failed to get selected country", zap.Error(err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		individual, err := repo.GetByID(ctx, mux.Vars(r)[pathParamIndividualID])
 		if err != nil {
 			l.Error("failed to get individual", zap.Error(err))
@@ -31,7 +39,7 @@ func HandleIndividualDelete(repo db.IndividualRepo) http.Handler {
 			return
 		}
 
-		if err := repo.SoftDelete(ctx, individual.ID); err != nil {
+		if err := repo.SoftDelete(ctx, individual.ID, countryID); err != nil {
 			l.Error("failed to delete individual", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/handlers/individual_delete.go
+++ b/internal/handlers/individual_delete.go
@@ -40,8 +40,8 @@ func HandleIndividualDelete(repo db.IndividualRepo) http.Handler {
 		}
 
 		if individual.CountryID != countryID {
-			l.Error("individual does not belong to selected country", zap.Error(err))
-			http.Error(w, fmt.Sprintf("individual does not belong to selected country"), http.StatusBadRequest)
+			l.Error("user trying to delete individual with the wrong country id", zap.String("individual_id", individual.ID))
+			http.Error(w, fmt.Sprintf("individual not found: %v", individual.ID), http.StatusNotFound)
 			return
 		}
 

--- a/internal/handlers/individual_delete.go
+++ b/internal/handlers/individual_delete.go
@@ -40,7 +40,7 @@ func HandleIndividualDelete(repo db.IndividualRepo) http.Handler {
 		}
 
 		if individual.CountryID != countryID {
-			l.Error("user trying to delete individual with the wrong country id", zap.String("individual_id", individual.ID))
+			l.Warn("user trying to delete individual with the wrong country id", zap.String("individual_id", individual.ID))
 			http.Error(w, fmt.Sprintf("individual not found: %v", individual.ID), http.StatusNotFound)
 			return
 		}

--- a/internal/handlers/individual_delete.go
+++ b/internal/handlers/individual_delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nrc-no/notcore/internal/db"
 	"github.com/nrc-no/notcore/internal/logging"
+	"github.com/nrc-no/notcore/internal/utils"
 	"go.uber.org/zap"
 )
 
@@ -24,10 +25,23 @@ func HandleIndividualDelete(repo db.IndividualRepo) http.Handler {
 			l   = logging.NewLogger(ctx)
 		)
 
+		countryID, err := utils.GetSelectedCountryID(ctx)
+		if err != nil {
+			l.Error("failed to get selected country", zap.Error(err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
 		individual, err := repo.GetByID(ctx, mux.Vars(r)[pathParamIndividualID])
 		if err != nil {
 			l.Error("failed to get individual", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if individual.CountryID != countryID {
+			l.Error("individual does not belong to selected country", zap.Error(err))
+			http.Error(w, fmt.Sprintf("individual does not belong to selected country"), http.StatusBadRequest)
 			return
 		}
 

--- a/internal/handlers/individual_delete.go
+++ b/internal/handlers/individual_delete.go
@@ -39,7 +39,8 @@ func HandleIndividualDelete(repo db.IndividualRepo) http.Handler {
 			return
 		}
 
-		if err := repo.SoftDelete(ctx, individual.ID, countryID); err != nil {
+
+		if err := repo.SoftDelete(ctx, individual.ID); err != nil {
 			l.Error("failed to delete individual", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/handlers/individual_delete.go
+++ b/internal/handlers/individual_delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nrc-no/notcore/internal/db"
 	"github.com/nrc-no/notcore/internal/logging"
-	"github.com/nrc-no/notcore/internal/utils"
 	"go.uber.org/zap"
 )
 
@@ -25,20 +24,12 @@ func HandleIndividualDelete(repo db.IndividualRepo) http.Handler {
 			l   = logging.NewLogger(ctx)
 		)
 
-		countryID, err := utils.GetSelectedCountryID(ctx)
-		if err != nil {
-			l.Error("failed to get selected country", zap.Error(err))
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
 		individual, err := repo.GetByID(ctx, mux.Vars(r)[pathParamIndividualID])
 		if err != nil {
 			l.Error("failed to get individual", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
 
 		if err := repo.SoftDelete(ctx, individual.ID); err != nil {
 			l.Error("failed to delete individual", zap.Error(err))

--- a/internal/handlers/individuals_delete.go
+++ b/internal/handlers/individuals_delete.go
@@ -27,10 +27,9 @@ func HandleIndividualsDelete(repo db.IndividualRepo) http.Handler {
 			l   = logging.NewLogger(ctx)
 		)
 
-		countryID, err := utils.GetSelectedCountryID(ctx)
-
 		individualIds := r.MultipartForm.Value[formParamField]
 
+		countryID, err := utils.GetSelectedCountryID(ctx)
 		if err != nil {
 			l.Error("failed to get selected country", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handlers/individuals_delete.go
+++ b/internal/handlers/individuals_delete.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-<<<<<<< HEAD
 	"github.com/nrc-no/notcore/internal/api"
-=======
->>>>>>> 3cca0ba (Add handler to soft delete many individuals)
 	"github.com/nrc-no/notcore/internal/db"
 	"github.com/nrc-no/notcore/internal/logging"
 	"github.com/nrc-no/notcore/internal/utils"
@@ -26,8 +23,6 @@ func HandleIndividualsDelete(repo db.IndividualRepo) http.Handler {
 			err error
 			l   = logging.NewLogger(ctx)
 		)
-
-		individualIds := r.MultipartForm.Value[formParamField]
 
 		countryID, err := utils.GetSelectedCountryID(ctx)
 		if err != nil {

--- a/internal/handlers/individuals_delete.go
+++ b/internal/handlers/individuals_delete.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
+<<<<<<< HEAD
 	"github.com/nrc-no/notcore/internal/api"
+=======
+>>>>>>> 3cca0ba (Add handler to soft delete many individuals)
 	"github.com/nrc-no/notcore/internal/db"
 	"github.com/nrc-no/notcore/internal/logging"
 	"github.com/nrc-no/notcore/internal/utils"
@@ -25,6 +28,9 @@ func HandleIndividualsDelete(repo db.IndividualRepo) http.Handler {
 		)
 
 		countryID, err := utils.GetSelectedCountryID(ctx)
+
+		individualIds := r.MultipartForm.Value[formParamField]
+
 		if err != nil {
 			l.Error("failed to get selected country", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handlers/individuals_delete.go
+++ b/internal/handlers/individuals_delete.go
@@ -48,7 +48,7 @@ func HandleIndividualsDelete(repo db.IndividualRepo) http.Handler {
 
 		invalidIndividualIds := validateIndividualsExistInCountry(individualIds, individuals, countryID)
 		if len(invalidIndividualIds) > 0 {
-			l.Error("user trying to delete individuals that don't exist or are in the wrong country", zap.Strings("individual_ids", invalidIndividualIds))
+			l.Warn("user trying to delete individuals that don't exist or are in the wrong country", zap.Strings("individual_ids", invalidIndividualIds))
 			http.Error(w, fmt.Sprintf("individuals not found: %v", invalidIndividualIds), http.StatusNotFound)
 			return
 		}

--- a/internal/handlers/individuals_delete.go
+++ b/internal/handlers/individuals_delete.go
@@ -58,6 +58,14 @@ func HandleIndividualsDelete(repo db.IndividualRepo) http.Handler {
 			return
 		}
 
+		for _, individual := range individuals {
+			if individual.CountryID != countryID {
+				l.Error("individual does not belong to selected country", zap.String("individual_id", individual.ID), zap.String("country_id", countryID))
+				http.Error(w, fmt.Sprintf("individual %s does not belong to selected country", individual.ID), http.StatusBadRequest)
+				return
+			}
+		}
+
 		if err := repo.SoftDeleteMany(ctx, individualIds); err != nil {
 			l.Error("failed to delete individuals", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handlers/individuals_upload.go
+++ b/internal/handlers/individuals_upload.go
@@ -84,7 +84,7 @@ func UploadHandler(individualRepo db.IndividualRepo) http.Handler {
 			}
 		}
 
-		existingIndividuals, err := individualRepo.ListByID(ctx, individualIds)
+		existingIndividuals, err := individualRepo.GetAll(ctx, api.GetAllOptions{IDs: individualIds})
 		if err != nil {
 			l.Error("failed to get existing individuals", zap.Error(err))
 			http.Error(w, "Internal server error", http.StatusInternalServerError)

--- a/internal/handlers/individuals_upload.go
+++ b/internal/handlers/individuals_upload.go
@@ -93,7 +93,7 @@ func UploadHandler(individualRepo db.IndividualRepo) http.Handler {
 
 		invalidIndividualIds := validateIndividualsExistInCountry(individualIds, existingIndividuals, selectedCountryID)
 		if len(invalidIndividualIds) > 0 {
-			l.Error("user trying to update individuals that don't exist or are in the wrong country", zap.Strings("individual_ids", invalidIndividualIds))
+			l.Warn("user trying to update individuals that don't exist or are in the wrong country", zap.Strings("individual_ids", invalidIndividualIds))
 			http.Error(w, fmt.Sprintf("individuals not found: %v", invalidIndividualIds), http.StatusNotFound)
 			return
 		}

--- a/internal/handlers/individuals_upload.go
+++ b/internal/handlers/individuals_upload.go
@@ -91,12 +91,11 @@ func UploadHandler(individualRepo db.IndividualRepo) http.Handler {
 			return
 		}
 
-		for _, individual := range existingIndividuals {
-			if individual.CountryID != selectedCountryID {
-				l.Error("trying to update individuals that do not belong to the selected country", zap.Error(err))
-				http.Error(w, "trying to update individuals that do not belong to the selected country", http.StatusBadRequest)
-				return
-			}
+		invalidIndividualIds := validateIndividualsExistInCountry(individualIds, existingIndividuals, selectedCountryID)
+		if len(invalidIndividualIds) > 0 {
+			l.Error("user trying to update individuals that don't exist or are in the wrong country", zap.Strings("individual_ids", invalidIndividualIds))
+			http.Error(w, fmt.Sprintf("individuals not found: %v", invalidIndividualIds), http.StatusNotFound)
+			return
 		}
 
 		_, err = individualRepo.PutMany(r.Context(), individuals, fields)

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -2,15 +2,16 @@ package handlers
 
 import (
 	"github.com/nrc-no/notcore/internal/api"
-	"golang.org/x/exp/slices"
+	"github.com/nrc-no/notcore/internal/containers"
 )
 
 func validateIndividualsExistInCountry(individualIds []string, existingIndividuals []*api.Individual, expectedCountryId string) []string {
-	var invalidIndividualIds []string
+	individualIdsSet := containers.NewStringSet(individualIds...)
+	invalidIndividualIds := containers.NewStringSet()
 	for _, individual := range existingIndividuals {
-		if individual.CountryID != expectedCountryId || !slices.Contains(individualIds, individual.ID) {
-			invalidIndividualIds = append(invalidIndividualIds, individual.ID)
+		if individual.CountryID != expectedCountryId || !individualIdsSet.Contains(individual.ID) {
+			invalidIndividualIds.Add(individual.ID)
 		}
 	}
-	return invalidIndividualIds
+	return invalidIndividualIds.Items()
 }

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	"github.com/nrc-no/notcore/internal/api"
+	"golang.org/x/exp/slices"
+)
+
+func validateIndividualsExistInCountry(individualIds []string, existingIndividuals []*api.Individual, expectedCountryId string) []string {
+	var invalidIndividualIds []string
+	for _, individual := range existingIndividuals {
+		if individual.CountryID != expectedCountryId || !slices.Contains(individualIds, individual.ID) {
+			invalidIndividualIds = append(invalidIndividualIds, individual.ID)
+		}
+	}
+	return invalidIndividualIds
+}


### PR DESCRIPTION
This PR works under the assumption that the `country_id` in the path param has been authorised (which it has).

* Prevent `country_id` column being updated in db
* `/countries/{country_id}/individuals/{individual_id}` - check individual's country id matches path param
* `/countries/{country_id}/individuals/{individual_id}/delete` - check individual's country id matches path param
* `/countries/{country_id}/individuals/{individual_id}/upload` - for all rows with an existing id that corresponds to an existing individual, check that the individual's country id matches path param