### PR TITLE
Fix filtering individuals by id

### DIFF
--- a/internal/constants/individual.go
+++ b/internal/constants/individual.go
@@ -16,6 +16,7 @@ const (
 	FormParamIndividualPresentsProtectionConcerns = "PresentsProtectionConcerns"
 	FormParamIndividualSensoryImpairment          = "SensoryImpairment"
 
+	FormParamGetIndividualsID                  = "id"
 	FormParamGetIndividualsEmail               = "email"
 	FormParamGetIndividualsName                = "name"
 	FormParamGetIndividualsPhoneNumber         = "phone_number"

--- a/internal/handlers/individuals.go
+++ b/internal/handlers/individuals.go
@@ -149,6 +149,7 @@ func parseGetAllOptions(r *http.Request, out *api.GetAllOptions) error {
 		displacementStatusMap[s] = true
 		out.DisplacementStatuses = append(out.DisplacementStatuses, s)
 	}
+	
 	idValues := r.Form[constants.FormParamGetIndividualsID]
 	idSet := containers.NewStringSet()
 	for _, v := range idValues {

--- a/internal/handlers/individuals.go
+++ b/internal/handlers/individuals.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/nrc-no/notcore/internal/api"
 	"github.com/nrc-no/notcore/internal/constants"
+	"github.com/nrc-no/notcore/internal/containers"
 	"github.com/nrc-no/notcore/internal/db"
 	"github.com/nrc-no/notcore/internal/logging"
 	"github.com/nrc-no/notcore/internal/utils"
@@ -147,5 +149,17 @@ func parseGetAllOptions(r *http.Request, out *api.GetAllOptions) error {
 		displacementStatusMap[s] = true
 		out.DisplacementStatuses = append(out.DisplacementStatuses, s)
 	}
+	idValues := r.Form[constants.FormParamGetIndividualsID]
+	idSet := containers.NewStringSet()
+	for _, v := range idValues {
+		parts := strings.Split(v, ",")
+		for _, p := range parts {
+			if len(p) == 0 {
+				continue
+			}
+			idSet.Add(p)
+		}
+	}
+	out.IDs = idSet.Items()
 	return nil
 }

--- a/web/templates/individuals.gohtml
+++ b/web/templates/individuals.gohtml
@@ -111,7 +111,7 @@
                                                    type="text"
                                                    placeholder="Search by ID"
                                                    class="form-control"
-                                                   value="{{.Options.IDs}}">
+                                                   value="{{if .Options.IDs}}{{joinStrings .Options.IDs ","}}{{end}}">
                                         </div>
                                         <!-- End ID -->
 


### PR DESCRIPTION
Logic was missing parsing the ids from the requests for filtering individuals. 
Also, the UI was showing an empty list literal `[]` when no individual ID was selected. Replaced by showing empty string when IDs is empty. 