### PR TITLE
COR-651: set correct default value for non-pointer time values

### DIFF
--- a/pkg/views/forms/codec_time.go
+++ b/pkg/views/forms/codec_time.go
@@ -25,6 +25,9 @@ func (c *TimeCodec) Encode(value interface{}) (string, error) {
 		}
 		return v.Format(c.format), nil
 	case time.Time:
+		if v.IsZero() {
+			return "", nil
+		}
 		return v.Format(c.format), nil
 	}
 	return "", fmt.Errorf("invalid value type")

--- a/pkg/views/forms/codec_time.go
+++ b/pkg/views/forms/codec_time.go
@@ -25,7 +25,7 @@ func (c *TimeCodec) Encode(value interface{}) (string, error) {
 		}
 		return v.Format(c.format), nil
 	case time.Time:
-		if v.IsZero() {
+		if (v == time.Time{}) || v.IsZero() {
 			return "", nil
 		}
 		return v.Format(c.format), nil


### PR DESCRIPTION
while encoding, non-pointer Time values where not checked for having been initialized