### PR TITLE
COR-740: stop page layout from jumping when loading content

### DIFF
--- a/web/templates/individuals.gohtml
+++ b/web/templates/individuals.gohtml
@@ -307,7 +307,7 @@
 
     {{$canWrite := .RequestContext.HasSelectedCountryWritePermission}}
 
-    <main class="container-fluid p-5 pt-0">
+    <main class="container-fluid px-5 pt-0">
         <div class="d-flex justify-content-between align-items-center">
             <h1 class="my-4">{{ $.RequestContext.SelectedCountry.Name }}</h1>
 
@@ -1484,7 +1484,7 @@
                     {{end}}
                 {{else}}
                     <tr>
-                        <td colspan="{{if not $canWrite}}30{{else}}31{{end}}">No individuals found</td>
+                        <td colspan="{{if not $canWrite}}30{{else}}31{{end}}">No participants found</td>
                     </tr>
                 {{end}}
                 </tbody>

--- a/web/theme/theme.scss
+++ b/web/theme/theme.scss
@@ -170,20 +170,27 @@ html, body {
 }
 
 body {
-    display: flex;
-    flex-direction: column;
+    height: 100%;
+    width: 100%;
 }
 
 header {
     height: $header-height;
-    width: 100%;
-    flex: none;
+    min-width: 850px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
 }
 
 main {
-    flex: auto;
-    height: calc(100% - $header-height - $footer-height - 20px);
-    width: 100%;
+    position: fixed;
+    top: $header-height;
+    bottom: $footer-height;
+    left: 0;
+    right: 0;
+    height: calc(100% - $header-height - $footer-height);
+    min-width: 850px;
     display: flex;
     flex-direction: column;
 
@@ -197,10 +204,13 @@ main {
 
 footer {
     height: $footer-height;
-    width: 100%;
+    min-width: 850px;
     padding: 0 25px;
     margin: auto;
-    flex: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
 };
 
 #filters {


### PR DESCRIPTION
the page footer dissapeared when a lot of data was loading, e.g. when going to the next page while showing 100 entries.

it still disappears, but the layout doesn't jump anymore.

also set a minimum width of 850px, also to keep the layout more stable, we're not mobile-ready, might be annoying to scroll horizontally, but they have to do that anyway for the table, and it looks nicer that way. 
can be discussed though.