### PR TITLE
fill up excel rows to be the same length

### DIFF
--- a/internal/api/individual_tabular.go
+++ b/internal/api/individual_tabular.go
@@ -66,6 +66,15 @@ func UnmarshalRecordsFromExcel(records *[][]string, reader io.Reader) error {
 	if err == nil {
 		*records = rows
 	}
+
+	for i, record := range *records {
+		header := (*records)[0]
+		diff := len(header) - len(record)
+		if diff > 0 {
+			filler := make([]string, diff)
+			(*records)[i] = append((*records)[i], filler...)
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
when a row has empty values at the end, the unmarshalling of the excel results in records of different lengths, which results in index errors