### PR TITLE
switch to 1.6.1

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -15,7 +15,7 @@ terraform {
   }
   backend "azurerm" {
   }
-  required_version = "1.5.7"
+  required_version = "1.6.1"
 }
 
 provider "azapi" {


### PR DESCRIPTION
got an error that version 1.6.0 was not supported by 1.5.7
1.6.0 seems to have a bug, which was apparently fixed in 1.6.1