### PR TITLE
fix(dependencies): disable dependabot version updates while keeping security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/" 
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Setting the [`open-pull-requests-limit`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit) to zero will stop dependabot from creating pull requests updating versions. But according to its documentation, security updates should not be affected.

This is a bit of a workaround, since there's no current (documented) support for Go for just enabling security updates without specifying version updates.