### PR TITLE
fix(infra): renamed virtual network link to be postgres specific

### DIFF
--- a/deploy/terraform/azurerm_postgresql_flexible_server.postgres.tf
+++ b/deploy/terraform/azurerm_postgresql_flexible_server.postgres.tf
@@ -22,7 +22,7 @@ resource "azurerm_postgresql_flexible_server" "postgres" {
   }
 
   depends_on = [
-    azurerm_private_dns_zone_virtual_network_link.vnet_link
+    azurerm_private_dns_zone_virtual_network_link.postgres_vnet_link
   ]
 
   lifecycle {

--- a/deploy/terraform/azurerm_private_dns_zone_virtual_network_link.postgres_vnet_link.tf
+++ b/deploy/terraform/azurerm_private_dns_zone_virtual_network_link.postgres_vnet_link.tf
@@ -1,7 +1,12 @@
-resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
+resource "azurerm_private_dns_zone_virtual_network_link" "postgres_vnet_link" {
   provider              = azurerm.runtime
   name                  = azurerm_private_dns_zone.postgres_dns.name
   private_dns_zone_name = azurerm_private_dns_zone.postgres_dns.name
   virtual_network_id    = azurerm_virtual_network.vnet.id
   resource_group_name   = azurerm_resource_group.rg.name
+}
+
+moved {
+  from = azurerm_private_dns_zone_virtual_network_link.vnet_link
+  to   = azurerm_private_dns_zone_virtual_network_link.postgres_vnet_link
 }


### PR DESCRIPTION
The virtual network link was called `vnet_link`, but it is specific to postgres dns zone, so renamed it to reflect that.

This change was originally part of https://github.com/NorwegianRefugeeCouncil/core/pull/290 but moved to this PR to ease its release. 
Otherwise it could generate problems as I'm releasing from that branch to test those changes, but making the rename would not allow to revert them.

Note the use of [`moved`](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring) to explicity make terraform use the existing resources. Once this is released and we don't have any further references to the old name, we can remove the `moved` block altogether (see docs linked above)