### PR TITLE
fix(upload): CPT-709 use db column ids mapping for identifying columns in files

### DIFF
--- a/internal/handlers/individuals_upload.go
+++ b/internal/handlers/individuals_upload.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nrc-no/notcore/internal/utils"
 	"github.com/nrc-no/notcore/pkg/api/deduplication"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 var UPLOAD_LIMIT = 10000
@@ -91,7 +90,8 @@ func HandleUpload(renderer Renderer, individualRepo db.IndividualRepo) http.Hand
 		deduplicationConfig, err := deduplication.GetDeduplicationConfig(deduplicationTypes, deduplicationLogicOperator)
 
 		mandatoryColumns := []string{constants.DBColumnIndividualLastName}
-		if _, idColumnExists := colMapping[constants.DBColumnIndividualID]; idColumnExists {
+		var idColumnExistsInFile bool
+		if _, idColumnExistsInFile = colMapping[constants.DBColumnIndividualID]; idColumnExistsInFile {
 			mandatoryColumns = append(mandatoryColumns, constants.DBColumnIndividualID)
 		}
 
@@ -107,7 +107,7 @@ func HandleUpload(renderer Renderer, individualRepo db.IndividualRepo) http.Hand
 			return
 		}
 
-		if slices.Contains(records[0], constants.FileColumnIndividualID) {
+		if idColumnExistsInFile {
 			fileErrors = api.FindDuplicatesInUUIDColumn(df)
 			if fileErrors != nil {
 				renderError(t("error_file_with_duplicate_uuids"), fileErrors)

--- a/internal/handlers/individuals_upload.go
+++ b/internal/handlers/individuals_upload.go
@@ -2,6 +2,9 @@ package handlers
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/nrc-no/notcore/internal/api"
 	"github.com/nrc-no/notcore/internal/constants"
 	"github.com/nrc-no/notcore/internal/containers"
@@ -12,8 +15,6 @@ import (
 	"github.com/nrc-no/notcore/pkg/api/deduplication"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
-	"net/http"
-	"strings"
 )
 
 var UPLOAD_LIMIT = 10000
@@ -90,7 +91,7 @@ func HandleUpload(renderer Renderer, individualRepo db.IndividualRepo) http.Hand
 		deduplicationConfig, err := deduplication.GetDeduplicationConfig(deduplicationTypes, deduplicationLogicOperator)
 
 		mandatoryColumns := []string{constants.DBColumnIndividualLastName}
-		if slices.Contains(records[0], constants.DBColumnIndividualID) {
+		if _, idColumnExists := colMapping[constants.DBColumnIndividualID]; idColumnExists {
 			mandatoryColumns = append(mandatoryColumns, constants.DBColumnIndividualID)
 		}
 


### PR DESCRIPTION
The issue was that we were comparing the localised header of the columns in the file to the name of the columns in the database, which in this case were `ID` against `id`, resulting in that column not being considered in the deduplication process.

Additionally found another similar issue, that was causing the `FindDuplicatesInUUIDColumn` function to never be executed, since it was trying to find a file column header named `file_id`. So I fixed it using the same approach above.