### PR TITLE
fix(deduplication): CPT-717 Conditionally ignore empty texts in deduplication fields

### DIFF
--- a/internal/db/individual_test.go
+++ b/internal/db/individual_test.go
@@ -1,6 +1,9 @@
 package db
 
 import (
+	"testing"
+	"time"
+
 	"github.com/go-gota/gota/dataframe"
 	"github.com/go-gota/gota/series"
 	"github.com/google/uuid"
@@ -8,8 +11,6 @@ import (
 	"github.com/nrc-no/notcore/internal/utils/pointers"
 	"github.com/nrc-no/notcore/pkg/api/deduplication"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestBuildTableSchemaQuery(t *testing.T) {
@@ -152,7 +153,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 		wantQuery         string
 	}{
 		{
-			"Deduplication query, no id column",
+			"Deduplication query, no id column, OR subquery",
 			"table_name",
 			deduplication.DeduplicationConfig{
 				deduplication.LOGICAL_OPERATOR_AND,
@@ -168,10 +169,10 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name);",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name != '' AND ti.full_name = ir.full_name));",
 		},
 		{
-			"Deduplication query, id column, deduplicate any",
+			"Deduplication query, id column, deduplicate any, OR subqueries",
 			"table_name",
 			deduplication.DeduplicationConfig{
 				deduplication.LOGICAL_OPERATOR_OR,
@@ -188,16 +189,16 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name) OR (ti.identification_number_1 = ir.identification_number_1 OR ti.identification_number_2 = ir.identification_number_2 OR ti.identification_number_3 = ir.identification_number_3) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name != '' AND ti.full_name = ir.full_name)) OR ((ti.identification_number_1 != '' AND ti.identification_number_1 = ir.identification_number_1) OR (ti.identification_number_2 != '' AND ti.identification_number_2 = ir.identification_number_2) OR (ti.identification_number_3 != '' AND ti.identification_number_3 = ir.identification_number_3)) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
 		},
 		{
-			"Deduplication query, id column, deduplicate all",
+			"Deduplication query, id column, deduplicate all, OR + AND subqueries",
 			"table_name",
 			deduplication.DeduplicationConfig{
 				deduplication.LOGICAL_OPERATOR_AND,
 				[]deduplication.DeduplicationType{
-					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameFullName],
-					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameIds],
+					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameEmails],
+					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameNames],
 				},
 			},
 			[]string{},
@@ -208,7 +209,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name) AND (ti.identification_number_1 = ir.identification_number_1 OR ti.identification_number_2 = ir.identification_number_2 OR ti.identification_number_3 = ir.identification_number_3) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
+			"SELECT DISTINCT ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.email_1 != '' AND ti.email_1 = ir.email_1) OR (ti.email_2 != '' AND ti.email_2 = ir.email_2) OR (ti.email_3 != '' AND ti.email_3 = ir.email_3)) AND (ti.first_name = ir.first_name AND ti.middle_name = ir.middle_name AND ti.last_name = ir.last_name AND ti.native_name = ir.native_name AND (ti.first_name != '' OR ti.middle_name != '' OR ti.last_name != '' OR ti.native_name != '')) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/api/deduplication/deduplicationTypes.go
+++ b/pkg/api/deduplication/deduplicationTypes.go
@@ -27,9 +27,17 @@ const (
 	LOGICAL_OPERATOR_AND LogicOperator = "AND"
 )
 
+type DataType string
+
+const (
+	DataTypeString DataType = "string"
+	DataTypeDate   DataType = "date"
+)
+
 type DeduplicationTypeValue struct {
 	Columns   []string
 	Condition LogicOperator
+	Type      DataType // defined as a single value since all columns have the same type at the moment, change to array if needed
 }
 
 type DeduplicationType struct {
@@ -51,6 +59,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 4,
 	},
@@ -60,6 +69,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 2,
 	},
@@ -69,6 +79,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 0,
 	},
@@ -78,6 +89,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName},
 			Condition: LOGICAL_OPERATOR_AND,
+			Type:      DataTypeString,
 		},
 		Order: 10,
 	},
@@ -87,6 +99,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualBirthDate},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeDate,
 		},
 		Order: 11,
 	},
@@ -96,6 +109,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualMothersName},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 8,
 	},
@@ -105,6 +119,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFullName},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 6,
 	},
@@ -114,6 +129,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField1},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 1,
 	},
@@ -123,6 +139,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField2},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 3,
 	},
@@ -132,6 +149,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 5,
 	},
@@ -141,6 +159,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField4},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 7,
 	},
@@ -150,6 +169,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField5},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 9,
 	},


### PR DESCRIPTION
https://norwegianrefugeecouncil.atlassian.net/browse/CPT-717

Changed the deduplication query builder, so empty strings are not considered.
Particularly, for OR subqueries we ignore them, and for AND subqueries we ignore them when all fields are empty (e.g. for anonymous participants)

I opted for updating the queries instead of defining columns as nullable, since the risk of messing other parts of the application is lower and the changes more contained. 
For v2 I'd rather suggest to work with null values and make a difference for what null vs empty means.