### PR TITLE
fix(deduplication): CPT-717 Defined subqueries considering empty strings

### DIFF
--- a/internal/db/individual.go
+++ b/internal/db/individual.go
@@ -225,25 +225,7 @@ func buildDeduplicationQuery(tempTableName string, columnsOfInterest []string, c
 
 	subQueries := []string{}
 	for _, dt := range config.Types {
-		subSubQueries := []string{}
-		cols := dt.Config.Columns
-		for _, c := range cols {
-			if dt.Config.Condition == deduplication.LOGICAL_OPERATOR_OR && dt.Config.Type == deduplication.DataTypeString {
-				// we don't want to compare empty strings
-				subSubQueries = append(subSubQueries, fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s)", c, c, c))
-			} else {
-				subSubQueries = append(subSubQueries, fmt.Sprintf("ti.%s = ir.%s", c, c))
-			}
-		}
-		if dt.Config.Condition == deduplication.LOGICAL_OPERATOR_AND && dt.Config.Type == deduplication.DataTypeString {
-			// ignore the sub query when all columns are empty
-			notEmptyChecks := []string{}
-			for _, c := range cols {
-				notEmptyChecks = append(notEmptyChecks, fmt.Sprintf("ti.%s != ''", c))
-			}
-			subSubQueries = append(subSubQueries, fmt.Sprintf("(%s)", strings.Join(notEmptyChecks, " OR ")))
-		}
-		subQueries = append(subQueries, strings.Join(subSubQueries, fmt.Sprintf(" %s ", dt.Config.Condition)))
+		subQueries = append(subQueries, dt.Config.Query)
 	}
 	if len(subQueries) > 0 {
 		b.WriteString(fmt.Sprintf(" AND (%s)", strings.Join(subQueries, fmt.Sprintf(") %s (", config.Operator))))

--- a/internal/db/individual_test.go
+++ b/internal/db/individual_test.go
@@ -169,7 +169,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name);",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name = ir.full_name) AND (ti.full_name != '' OR ir.full_name != ''));",
 		},
 		{
 			"Deduplication query, id column, deduplicate any, OR subqueries",
@@ -189,7 +189,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name) OR ((ti.identification_number_1 != '' AND ti.identification_number_1 = ir.identification_number_1) OR (ti.identification_number_2 != '' AND ti.identification_number_2 = ir.identification_number_2) OR (ti.identification_number_3 != '' AND ti.identification_number_3 = ir.identification_number_3)) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name != '' AND ti.full_name = ir.full_name) OR ((ti.identification_number_1 != '' AND ti.identification_number_1 = ir.identification_number_1) OR (ti.identification_number_2 != '' AND ti.identification_number_2 = ir.identification_number_2) OR (ti.identification_number_3 != '' AND ti.identification_number_3 = ir.identification_number_3))) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
 		},
 		{
 			"Deduplication query, id column, deduplicate all, OR + AND subqueries",
@@ -209,7 +209,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.email_1 != '' AND ti.email_1 = ir.email_1) OR (ti.email_2 != '' AND ti.email_2 = ir.email_2) OR (ti.email_3 != '' AND ti.email_3 = ir.email_3)) AND (ti.first_name = ir.first_name AND ti.middle_name = ir.middle_name AND ti.last_name = ir.last_name AND ti.native_name = ir.native_name AND (ti.first_name != '' OR ti.middle_name != '' OR ti.last_name != '' OR ti.native_name != '')) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
+			"SELECT DISTINCT ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (((ti.email_1 != '' AND ti.email_1 = ir.email_1) OR (ti.email_2 != '' AND ti.email_2 = ir.email_2) OR (ti.email_3 != '' AND ti.email_3 = ir.email_3) OR (ti.email_1 = '' AND ti.email_2 = '' AND ti.email_3 ='')) AND (ti.first_name = ir.first_name AND ti.middle_name = ir.middle_name AND ti.last_name = ir.last_name AND ti.native_name = ir.native_name) AND (ti.email_1 != '' OR ir.email_1 != '' OR ti.email_2 != '' OR ir.email_2 != '' OR ti.email_3 != '' OR ir.email_3 != '' OR ti.first_name != '' OR ir.first_name != '' OR ti.middle_name != '' OR ir.middle_name != '' OR ti.last_name != '' OR ir.last_name != '' OR ti.native_name != '' OR ir.native_name != '')) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/db/individual_test.go
+++ b/internal/db/individual_test.go
@@ -169,7 +169,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name != '' AND ti.full_name = ir.full_name));",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name);",
 		},
 		{
 			"Deduplication query, id column, deduplicate any, OR subqueries",
@@ -189,7 +189,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name != '' AND ti.full_name = ir.full_name)) OR ((ti.identification_number_1 != '' AND ti.identification_number_1 = ir.identification_number_1) OR (ti.identification_number_2 != '' AND ti.identification_number_2 = ir.identification_number_2) OR (ti.identification_number_3 != '' AND ti.identification_number_3 = ir.identification_number_3)) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name) OR ((ti.identification_number_1 != '' AND ti.identification_number_1 = ir.identification_number_1) OR (ti.identification_number_2 != '' AND ti.identification_number_2 = ir.identification_number_2) OR (ti.identification_number_3 != '' AND ti.identification_number_3 = ir.identification_number_3)) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
 		},
 		{
 			"Deduplication query, id column, deduplicate all, OR + AND subqueries",

--- a/internal/db/individual_test.go
+++ b/internal/db/individual_test.go
@@ -1,6 +1,9 @@
 package db
 
 import (
+	"testing"
+	"time"
+
 	"github.com/go-gota/gota/dataframe"
 	"github.com/go-gota/gota/series"
 	"github.com/google/uuid"
@@ -8,8 +11,6 @@ import (
 	"github.com/nrc-no/notcore/internal/utils/pointers"
 	"github.com/nrc-no/notcore/pkg/api/deduplication"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestBuildTableSchemaQuery(t *testing.T) {
@@ -152,7 +153,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 		wantQuery         string
 	}{
 		{
-			"Deduplication query, no id column",
+			"Deduplication query, no id column, OR subquery",
 			"table_name",
 			deduplication.DeduplicationConfig{
 				deduplication.LOGICAL_OPERATOR_AND,
@@ -168,10 +169,10 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name);",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name != '' AND ti.full_name = ir.full_name));",
 		},
 		{
-			"Deduplication query, id column, deduplicate any",
+			"Deduplication query, id column, deduplicate any, OR subqueries",
 			"table_name",
 			deduplication.DeduplicationConfig{
 				deduplication.LOGICAL_OPERATOR_OR,
@@ -188,16 +189,16 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name) OR (ti.identification_number_1 = ir.identification_number_1 OR ti.identification_number_2 = ir.identification_number_2 OR ti.identification_number_3 = ir.identification_number_3) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
+			"SELECT DISTINCT ir.col_text_1,ir.col_date,ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.full_name != '' AND ti.full_name = ir.full_name)) OR ((ti.identification_number_1 != '' AND ti.identification_number_1 = ir.identification_number_1) OR (ti.identification_number_2 != '' AND ti.identification_number_2 = ir.identification_number_2) OR (ti.identification_number_3 != '' AND ti.identification_number_3 = ir.identification_number_3)) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
 		},
 		{
-			"Deduplication query, id column, deduplicate all",
+			"Deduplication query, id column, deduplicate all, OR + AND subqueries",
 			"table_name",
 			deduplication.DeduplicationConfig{
 				deduplication.LOGICAL_OPERATOR_AND,
 				[]deduplication.DeduplicationType{
-					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameFullName],
-					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameIds],
+					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameEmails],
+					deduplication.DeduplicationTypes[deduplication.DeduplicationTypeNameNames],
 				},
 			},
 			[]string{},
@@ -208,7 +209,7 @@ func TestBuildDeduplicationQuery(t *testing.T) {
 				{Name: "col_text_2", SQLType: "text", Default: nil},
 				{Name: "col_date", SQLType: "timestamp", Default: nil},
 			},
-			"SELECT DISTINCT ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND (ti.full_name = ir.full_name) AND (ti.identification_number_1 = ir.identification_number_1 OR ti.identification_number_2 = ir.identification_number_2 OR ti.identification_number_3 = ir.identification_number_3) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
+			"SELECT DISTINCT ir.id FROM individual_registrations ir CROSS JOIN table_name ti WHERE ir.country_id = $1 AND ir.deleted_at IS NULL AND ((ti.email_1 != '' AND ti.email_1 = ir.email_1) OR (ti.email_2 != '' AND ti.email_2 = ir.email_2) OR (ti.email_3 != '' AND ti.email_3 = ir.email_3)) AND (ti.first_name = ir.first_name AND ti.middle_name = ir.middle_name AND ti.last_name = ir.last_name AND ti.native_name = ir.native_name AND (ti.first_name != '' OR ti.middle_name != '' OR ti.last_name != '' OR ti.native_name != '')) AND ti.id::uuid NOT IN (SELECT id FROM individual_registrations);",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/api/deduplication/deduplicationTypes.go
+++ b/pkg/api/deduplication/deduplicationTypes.go
@@ -27,9 +27,17 @@ const (
 	LOGICAL_OPERATOR_AND LogicOperator = "AND"
 )
 
+type DataType string
+
+const (
+	DataTypeString DataType = "string"
+	DataTypeDate   DataType = "date"
+)
+
 type DeduplicationTypeValue struct {
 	Columns   []string
 	Condition LogicOperator
+	Type      DataType // defined as a single value since all columns have the same type at the moment, change to array if needed
 }
 
 type DeduplicationType struct {
@@ -51,6 +59,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 4,
 	},
@@ -60,6 +69,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 2,
 	},
@@ -69,6 +79,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 0,
 	},
@@ -78,6 +89,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName},
 			Condition: LOGICAL_OPERATOR_AND,
+			Type:      DataTypeString,
 		},
 		Order: 10,
 	},
@@ -87,6 +99,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualBirthDate},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeDate,
 		},
 		Order: 11,
 	},
@@ -96,6 +109,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualMothersName},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 8,
 	},
@@ -105,6 +119,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFullName},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 6,
 	},
@@ -114,6 +129,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField1},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 1,
 	},
@@ -123,6 +139,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField2},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 3,
 	},
@@ -132,6 +149,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 5,
 	},
@@ -141,6 +159,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField4},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 7,
 	},
@@ -150,6 +169,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField5},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 		},
 		Order: 9,
 	},

--- a/pkg/api/deduplication/deduplicationTypes.go
+++ b/pkg/api/deduplication/deduplicationTypes.go
@@ -29,19 +29,12 @@ const (
 	LOGICAL_OPERATOR_AND LogicOperator = "AND"
 )
 
-type DataType string
-
-const (
-	DataTypeString DataType = "string"
-	DataTypeDate   DataType = "date"
-)
-
 type DeduplicationTypeValue struct {
-	Columns   []string
-	Condition LogicOperator
-	Type      DataType // defined as a single value since all columns have the same type at the moment, change to array if needed
-	QueryAnd  string
-	QueryOr   string
+	Columns          []string
+	Condition        LogicOperator
+	QueryAnd         string
+	QueryOr          string
+	QueryNotAllEmpty string
 }
 
 type DeduplicationType struct {
@@ -63,7 +56,6 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
 				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1,
 				constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2,
@@ -73,6 +65,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1,
 				constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2,
 				constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1,
+				constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2,
+				constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3),
 		},
 		Order: 4,
 	},
@@ -82,7 +78,6 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
 				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1,
 				constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2,
@@ -92,6 +87,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1,
 				constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2,
 				constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1,
+				constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2,
+				constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3),
 		},
 		Order: 2,
 	},
@@ -101,7 +100,6 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
 				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1,
 				constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2,
@@ -111,6 +109,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1,
 				constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2,
 				constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1,
+				constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2,
+				constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3),
 		},
 		Order: 0,
 	},
@@ -120,7 +122,6 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName},
 			Condition: LOGICAL_OPERATOR_AND,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualFirstName,
 				constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualMiddleName,
@@ -133,6 +134,11 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 				constants.DBColumnIndividualNativeName, constants.DBColumnIndividualNativeName,
 				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName,
 				constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != '' OR ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualFirstName,
+				constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualMiddleName,
+				constants.DBColumnIndividualLastName, constants.DBColumnIndividualLastName,
+				constants.DBColumnIndividualNativeName, constants.DBColumnIndividualNativeName),
 		},
 		Order: 10,
 	},
@@ -142,7 +148,6 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualBirthDate},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeDate,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualBirthDate, constants.DBColumnIndividualBirthDate),
 			QueryOr: fmt.Sprintf("ti.%s = ir.%s",
@@ -156,11 +161,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualMothersName},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
 				constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName),
 		},
 		Order: 8,
 	},
@@ -170,11 +176,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFullName},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName),
 		},
 		Order: 6,
 	},
@@ -184,11 +191,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField1},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1),
 		},
 		Order: 1,
 	},
@@ -198,11 +206,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField2},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2),
 		},
 		Order: 3,
 	},
@@ -212,11 +221,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3),
 		},
 		Order: 5,
 	},
@@ -226,11 +236,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField4},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4),
 		},
 		Order: 7,
 	},
@@ -240,11 +251,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField5},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5),
+			QueryNotAllEmpty: fmt.Sprintf("ti.%s != '' OR ir.%s != ''",
+				constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5),
 		},
 		Order: 9,
 	},

--- a/pkg/api/deduplication/deduplicationTypes.go
+++ b/pkg/api/deduplication/deduplicationTypes.go
@@ -29,9 +29,17 @@ const (
 	LOGICAL_OPERATOR_AND LogicOperator = "AND"
 )
 
+type DataType string
+
+const (
+	DataTypeString DataType = "string"
+	DataTypeDate   DataType = "date"
+)
+
 type DeduplicationTypeValue struct {
 	Columns   []string
 	Condition LogicOperator
+	Type      DataType // defined as a single value since all columns have the same type at the moment, change to array if needed
 	QueryAnd  string
 	QueryOr   string
 }
@@ -55,6 +63,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
 				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1,
 				constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2,
@@ -73,6 +82,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
 				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1,
 				constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2,
@@ -91,6 +101,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
 				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1,
 				constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2,
@@ -109,6 +120,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName},
 			Condition: LOGICAL_OPERATOR_AND,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s",
 				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualFirstName,
 				constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualMiddleName,
@@ -130,6 +142,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualBirthDate},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeDate,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualBirthDate, constants.DBColumnIndividualBirthDate),
 			QueryOr: fmt.Sprintf("ti.%s = ir.%s",
@@ -143,6 +156,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualMothersName},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
@@ -156,6 +170,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFullName},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
@@ -169,6 +184,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField1},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
@@ -182,6 +198,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField2},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
@@ -195,6 +212,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField3},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
@@ -208,6 +226,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField4},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
@@ -221,6 +240,7 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField5},
 			Condition: LOGICAL_OPERATOR_OR,
+			Type:      DataTypeString,
 			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5),
 			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",

--- a/pkg/api/deduplication/deduplicationTypes.go
+++ b/pkg/api/deduplication/deduplicationTypes.go
@@ -32,7 +32,8 @@ const (
 type DeduplicationTypeValue struct {
 	Columns   []string
 	Condition LogicOperator
-	Query     string
+	QueryAnd  string
+	QueryOr   string
 }
 
 type DeduplicationType struct {
@@ -54,7 +55,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
+			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
+				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1,
+				constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2,
+				constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3,
+				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber3),
+			QueryOr: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
 				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1,
 				constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2,
 				constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3),
@@ -67,7 +73,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
+			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
+				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1,
+				constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2,
+				constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3,
+				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail3),
+			QueryOr: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
 				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1,
 				constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2,
 				constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3),
@@ -80,7 +91,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
+			QueryAnd: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s = '' AND ti.%s = '' AND ti.%s ='')",
+				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1,
+				constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2,
+				constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3,
+				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber3),
+			QueryOr: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
 				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1,
 				constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2,
 				constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3),
@@ -93,7 +109,12 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName},
 			Condition: LOGICAL_OPERATOR_AND,
-			Query: fmt.Sprintf("ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND (ti.%s != '' OR ti.%s != '' OR ti.%s != '' OR ti.%s != '')",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s",
+				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualFirstName,
+				constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualMiddleName,
+				constants.DBColumnIndividualLastName, constants.DBColumnIndividualLastName,
+				constants.DBColumnIndividualNativeName, constants.DBColumnIndividualNativeName),
+			QueryOr: fmt.Sprintf("ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND (ti.%s != '' OR ti.%s != '' OR ti.%s != '' OR ti.%s != '')",
 				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualFirstName,
 				constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualMiddleName,
 				constants.DBColumnIndividualLastName, constants.DBColumnIndividualLastName,
@@ -109,7 +130,9 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualBirthDate},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualBirthDate, constants.DBColumnIndividualBirthDate),
+			QueryOr: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualBirthDate, constants.DBColumnIndividualBirthDate),
 		},
 		Order: 11,
@@ -120,8 +143,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualMothersName},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName),
+			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
+				constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName),
 		},
 		Order: 8,
 	},
@@ -131,8 +156,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFullName},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName),
+			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
+				constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName),
 		},
 		Order: 6,
 	},
@@ -142,8 +169,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField1},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1),
+			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1),
 		},
 		Order: 1,
 	},
@@ -153,8 +182,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField2},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2),
+			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2),
 		},
 		Order: 3,
 	},
@@ -164,8 +195,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3),
+			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3),
 		},
 		Order: 5,
 	},
@@ -175,8 +208,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField4},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4),
+			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4),
 		},
 		Order: 7,
 	},
@@ -186,8 +221,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField5},
 			Condition: LOGICAL_OPERATOR_OR,
-			Query: fmt.Sprintf("ti.%s = ir.%s",
+			QueryAnd: fmt.Sprintf("ti.%s = ir.%s",
 				constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5),
+			QueryOr: fmt.Sprintf("ti.%s != '' AND ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5),
 		},
 		Order: 9,
 	},

--- a/pkg/api/deduplication/deduplicationTypes.go
+++ b/pkg/api/deduplication/deduplicationTypes.go
@@ -1,6 +1,8 @@
 package deduplication
 
 import (
+	"fmt"
+
 	"github.com/nrc-no/notcore/internal/constants"
 )
 
@@ -27,17 +29,10 @@ const (
 	LOGICAL_OPERATOR_AND LogicOperator = "AND"
 )
 
-type DataType string
-
-const (
-	DataTypeString DataType = "string"
-	DataTypeDate   DataType = "date"
-)
-
 type DeduplicationTypeValue struct {
 	Columns   []string
 	Condition LogicOperator
-	Type      DataType // defined as a single value since all columns have the same type at the moment, change to array if needed
+	Query     string
 }
 
 type DeduplicationType struct {
@@ -59,7 +54,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
+				constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1, constants.DBColumnIndividualPhoneNumber1,
+				constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2, constants.DBColumnIndividualPhoneNumber2,
+				constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3, constants.DBColumnIndividualPhoneNumber3),
 		},
 		Order: 4,
 	},
@@ -69,7 +67,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
+				constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1, constants.DBColumnIndividualEmail1,
+				constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2, constants.DBColumnIndividualEmail2,
+				constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3, constants.DBColumnIndividualEmail3),
 		},
 		Order: 2,
 	},
@@ -79,7 +80,10 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("(ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s) OR (ti.%s != '' AND ti.%s = ir.%s)",
+				constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1, constants.DBColumnIndividualIdentificationNumber1,
+				constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2, constants.DBColumnIndividualIdentificationNumber2,
+				constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3, constants.DBColumnIndividualIdentificationNumber3),
 		},
 		Order: 0,
 	},
@@ -89,7 +93,13 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName},
 			Condition: LOGICAL_OPERATOR_AND,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND ti.%s = ir.%s AND (ti.%s != '' OR ti.%s != '' OR ti.%s != '' OR ti.%s != '')",
+				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualFirstName,
+				constants.DBColumnIndividualMiddleName, constants.DBColumnIndividualMiddleName,
+				constants.DBColumnIndividualLastName, constants.DBColumnIndividualLastName,
+				constants.DBColumnIndividualNativeName, constants.DBColumnIndividualNativeName,
+				constants.DBColumnIndividualFirstName, constants.DBColumnIndividualMiddleName,
+				constants.DBColumnIndividualLastName, constants.DBColumnIndividualNativeName),
 		},
 		Order: 10,
 	},
@@ -99,7 +109,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualBirthDate},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeDate,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualBirthDate, constants.DBColumnIndividualBirthDate),
 		},
 		Order: 11,
 	},
@@ -109,7 +120,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualMothersName},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualMothersName, constants.DBColumnIndividualMothersName),
 		},
 		Order: 8,
 	},
@@ -119,7 +131,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFullName},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualFullName, constants.DBColumnIndividualFullName),
 		},
 		Order: 6,
 	},
@@ -129,7 +142,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField1},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField1, constants.DBColumnIndividualFreeField1),
 		},
 		Order: 1,
 	},
@@ -139,7 +153,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField2},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField2, constants.DBColumnIndividualFreeField2),
 		},
 		Order: 3,
 	},
@@ -149,7 +164,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField3},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField3, constants.DBColumnIndividualFreeField3),
 		},
 		Order: 5,
 	},
@@ -159,7 +175,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField4},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField4, constants.DBColumnIndividualFreeField4),
 		},
 		Order: 7,
 	},
@@ -169,7 +186,8 @@ var DeduplicationTypes = map[DeduplicationTypeName]DeduplicationType{
 		Config: DeduplicationTypeValue{
 			Columns:   []string{constants.DBColumnIndividualFreeField5},
 			Condition: LOGICAL_OPERATOR_OR,
-			Type:      DataTypeString,
+			Query: fmt.Sprintf("ti.%s = ir.%s",
+				constants.DBColumnIndividualFreeField5, constants.DBColumnIndividualFreeField5),
 		},
 		Order: 9,
 	},


### PR DESCRIPTION
https://norwegianrefugeecouncil.atlassian.net/browse/CPT-717

Alternative solution to https://github.com/NorwegianRefugeeCouncil/core/pull/298 

Changed the deduplication query builder, so empty strings are not considered.
Particularly, for OR subqueries we ignore them, and for AND subqueries we ignore them when all fields are empty (e.g. for anonymous participants)

I opted for updating the queries instead of defining columns as nullable, since the risk of messing other parts of the application is lower and the changes more contained. 
For v2 I'd rather suggest to work with null values and make a difference for what null vs empty means.

This one defined the subqueries directly in the dedup configuration, simplifying the approach but increasing coupling.

Also extended it to consider edge cases.
- If ALL fields in the criteria are empty, two entries are not considered as the same.
- If some fields in the criteria are empty, those fields are ignored and the non-empty ones considered for deduplication.