### PR TITLE
feat(individuals): CPT-206 Hard delete individuals in db

### DIFF
--- a/internal/db/const.go
+++ b/internal/db/const.go
@@ -1,31 +1,7 @@
 package db
 
-import "time"
-
 // maxParams is the maximum number of arguments that can be passed to a postgres query
 const maxParams = 65535
-
-type individualActionConfig struct {
-	conditions  []string
-	targetField string
-	newValue    any
-}
-
-var deleteAction = individualActionConfig{
-	conditions:  []string{"and deleted_at IS NULL"},
-	targetField: "deleted_at",
-	newValue:    time.Now().UTC().Format(time.RFC3339),
-}
-var activateAction = individualActionConfig{
-	conditions:  []string{},
-	targetField: "inactive",
-	newValue:    false,
-}
-var deactivateAction = individualActionConfig{
-	conditions:  []string{},
-	targetField: "inactive",
-	newValue:    true,
-}
 
 type IndividualAction string
 
@@ -34,9 +10,3 @@ const (
 	ActivateAction   IndividualAction = "activate"
 	DeactivateAction IndividualAction = "deactivate"
 )
-
-var individualActionsConfig = map[IndividualAction]individualActionConfig{
-	DeleteAction:     deleteAction,
-	ActivateAction:   activateAction,
-	DeactivateAction: deactivateAction,
-}

--- a/internal/db/const.go
+++ b/internal/db/const.go
@@ -5,35 +5,37 @@ import "time"
 // maxParams is the maximum number of arguments that can be passed to a postgres query
 const maxParams = 65535
 
-type individualAction struct {
+type individualActionConfig struct {
 	conditions  []string
 	targetField string
 	newValue    any
 }
 
-var deleteAction = individualAction{
+var deleteAction = individualActionConfig{
 	conditions:  []string{"and deleted_at IS NULL"},
 	targetField: "deleted_at",
 	newValue:    time.Now().UTC().Format(time.RFC3339),
 }
-var activateAction = individualAction{
+var activateAction = individualActionConfig{
 	conditions:  []string{},
 	targetField: "inactive",
 	newValue:    false,
 }
-var deactivateAction = individualAction{
+var deactivateAction = individualActionConfig{
 	conditions:  []string{},
 	targetField: "inactive",
 	newValue:    true,
 }
 
+type IndividualAction string
+
 const (
-	DeleteAction     string = "delete"
-	ActivateAction          = "activate"
-	DeactivateAction        = "deactivate"
+	DeleteAction     IndividualAction = "delete"
+	ActivateAction   IndividualAction = "activate"
+	DeactivateAction IndividualAction = "deactivate"
 )
 
-var individualActions = map[string]individualAction{
+var individualActionsConfig = map[IndividualAction]individualActionConfig{
 	DeleteAction:     deleteAction,
 	ActivateAction:   activateAction,
 	DeactivateAction: deactivateAction,

--- a/internal/handlers/individual_action.go
+++ b/internal/handlers/individual_action.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func HandleIndividualAction(repo db.IndividualRepo, action string) http.Handler {
+func HandleIndividualAction(repo db.IndividualRepo, action db.IndividualAction) http.Handler {
 
 	const (
 		pathParamIndividualID = "individual_id"

--- a/internal/handlers/individuals_action.go
+++ b/internal/handlers/individuals_action.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/nrc-no/notcore/internal/api"
 	"github.com/nrc-no/notcore/internal/containers"
 	"github.com/nrc-no/notcore/internal/db"
@@ -9,10 +11,9 @@ import (
 	"github.com/nrc-no/notcore/internal/logging"
 	"github.com/nrc-no/notcore/internal/utils"
 	"go.uber.org/zap"
-	"net/http"
 )
 
-func HandleIndividualsAction(renderer Renderer, repo db.IndividualRepo, action string) http.Handler {
+func HandleIndividualsAction(renderer Renderer, repo db.IndividualRepo, action db.IndividualAction) http.Handler {
 
 	const (
 		templateName   = "error.gohtml"
@@ -70,14 +71,14 @@ func HandleIndividualsAction(renderer Renderer, repo db.IndividualRepo, action s
 			for _, individualId := range invalidIndividualIds {
 				errors = append(errors, fmt.Errorf(individualId))
 			}
-			l.Warn("user trying to "+action+" individuals that don't exist or are in the wrong country", zap.Strings("individual_ids", invalidIndividualIds))
+			l.Warn("user trying to "+string(action)+" individuals that don't exist or are in the wrong country", zap.Strings("individual_ids", invalidIndividualIds))
 			renderError(t("error_action_execution", action),
 				[]api.FileError{{Message: t("error_action_failed"), Err: errors}})
 			return
 		}
 
 		if err := repo.PerformActionMany(ctx, individualIds, action); err != nil {
-			l.Error("failed to "+action+" individuals", zap.Error(err))
+			l.Error("failed to "+string(action)+" individuals", zap.Error(err))
 			renderError(t("error_action_failed_detail", action), nil)
 			return
 		}


### PR DESCRIPTION
https://norwegianrefugeecouncil.atlassian.net/browse/CPT-206

First stage to rollout deleting individual entries from the database (instead of setting the `deleted_at` value)
At this stage, new delete requests directly remove the rows from the table.
Additionally added a type for Individual actions, to restrict the possible string values passed around.

Next stages are:
- After releasing these changes, execute `DELETE FROM individual_registrations WHERE deleted_at IS NOT NULL;` to remove all existing soft-deleted entries.
- Remove the usage of the `deleted_at` column from the codebase, since at this point all entries will have `NULL` value in the database.
- After release of the previous change, drop the column from the table.

 