### PR TITLE
[CORE24-122] task(setup): use docker compose for db and oidc local dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ testem.log
 Thumbs.db
 
 .nx/cache
+
+config/certs/*
+!config/certs/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # core
+
+## Dependencies
+### mkcert
+#### on Linux
+##### Install [homebrew](https://brew.sh/)
+```
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+##### Install nss-tools and mkcert
+```
+sudo apt install libnss3-tools        # Debian, Ubuntu
+sudo yum install nss-tools            # CentOS, RHEL
+sudo pacman -S nss                    # Arch Linux
+sudo zypper install mozilla-nss-tools # openSUSE
+sudo dnf install nss-tools            # Fedora
+brew install mkcert                   # Install mkcert
+```
+
+#### on macOS
+```
+brew install mkcert
+brew install nss # if you use Firefox
+```
+
+### TLS certificates
+```
+./scripts/create-local-tls-certificate.sh
+```
+

--- a/apps/core-api/project.json
+++ b/apps/core-api/project.json
@@ -18,6 +18,27 @@
           "buildTarget": "core-api:build:production"
         }
       }
+    },
+    "compose": {
+      "executor": "nx:run-commands",
+      "configurations": {
+        "up": {
+          "command": "docker compose up -d --build"
+        },
+        "down": {
+          "command": "docker compose down"
+        }
+      }
+    },
+    "local-serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "nx run core-api:compose:up",
+          "nx run core-api:serve"
+        ],
+        "parallel": false
+      }
     }
   },
   "tags": []

--- a/config/envoy.yaml
+++ b/config/envoy.yaml
@@ -1,0 +1,250 @@
+admin:
+  access_log_path: /dev/stdout
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9010
+
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 10000
+      filter_chains:
+        - transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              common_tls_context:
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /etc/envoy/certs/tls.crt
+                    private_key:
+                      filename: /etc/envoy/certs/tls.key
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: AUTO
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_web
+                      domains:
+                        - "*"
+                      typed_per_filter_config:
+                        envoy.filters.http.ext_authz:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                          check_settings:
+                            context_extensions:
+                              virtual_host: local_web
+                              x-forwarded-host: original-host-as-context
+                      routes:
+                        - match:
+                            prefix: /certs
+                          route:
+                            cluster: oidc
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: /.well-known
+                          route:
+                            cluster: oidc
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: /auth
+                          route:
+                            cluster: oidc
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: /token
+                          route:
+                            cluster: oidc
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: /me
+                          route:
+                            cluster: oidc
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: /session
+                          route:
+                            cluster: oidc
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: /interaction
+                          route:
+                            cluster: oidc
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: /oauth2
+                          route:
+                            cluster: oauth2_proxy
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: "/static"
+                          route:
+                            cluster: web
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                        - match:
+                            prefix: ""
+                          route:
+                            cluster: web
+                            timeout: 600s
+                http_filters:
+                  - name: envoy.filters.http.ext_authz
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                      http_service:
+                        server_uri:
+                          uri: 127.0.0.1:4180
+                          cluster: oauth2_proxy
+                          timeout: 0.250s
+                        path_prefix: ""
+                        authorization_request:
+                          allowed_headers:
+                            patterns:
+                              - exact: cookie
+                                ignore_case: true
+                              - exact: authorization
+                                ignore_case: true
+                        authorization_response:
+                          allowed_client_headers:
+                            patterns:
+                              - exact: set-cookie
+                                ignore_case: true
+                              - exact: content-type
+                                ignore_case: true
+                          allowed_upstream_headers_to_append:
+                            patterns:
+                              - exact: set-cookie
+                          allowed_upstream_headers:
+                            patterns:
+                              - exact: authorization
+                                ignore_case: true
+                              - exact: path
+                                ignore_case: true
+                              - exact: x-auth-request-user
+                                ignore_case: true
+                              - exact: x-auth-request-email
+                                ignore_case: true
+                              - exact: x-auth-request-groups
+                                ignore_case: true
+                              - exact: x-auth-request-preferred-username
+                                ignore_case: true
+                              - exact: x-auth-request-access-token
+                                ignore_case: true
+                              - exact: x-auth-request-id-token
+                                ignore_case: true
+                  - name: envoy.filters.http.jwt_authn
+                    typed_config:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                      providers:
+                        origins-0:
+                          issuer: https://localhost:10000
+                          audiences:
+                            - foo
+                          forward: true
+                          forward_payload_header: x-jwt-payload
+                          remote_jwks:
+                            http_uri:
+                              uri: http://localhost:4080/certs
+                              cluster: oidc
+                              timeout: 5s
+                            cache_duration:
+                              seconds: 300
+                          payload_in_metadata: https://localhost:10000
+                      rules:
+                        - match:
+                            prefix: /certs
+                        - match:
+                            prefix: /auth
+                        - match:
+                            prefix: /token
+                        - match:
+                            prefix: /me
+                        - match:
+                            prefix: /interaction
+                        - match:
+                            prefix: /oauth
+                        - match:
+                            prefix: /static
+                        - match:
+                            prefix: /
+                          requires:
+                            requires_any:
+                              requirements:
+                                - provider_name: origins-0
+                                - allow_missing: { }
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: web
+      connect_timeout: 0.25s
+      type: LOGICAL_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: web
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: host.docker.internal
+                      port_value: 8080
+    - name: oidc
+      connect_timeout: 0.25s
+      type: LOGICAL_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: oidc
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: oidc
+                      port_value: 9000
+    - name: oauth2_proxy
+      connect_timeout: 0.25s
+      type: LOGICAL_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: oauth2_proxy
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: oauth2-proxy
+                      port_value: 4180

--- a/config/oidc-config.json
+++ b/config/oidc-config.json
@@ -1,0 +1,35 @@
+{
+  "idp_name": "https://localhost:10000",
+  "port": 9000,
+  "client_config": [
+    {
+      "client_id": "foo",
+      "client_secret": "bar",
+      "redirect_uris": [
+        "https://localhost:10000/oauth2/callback"
+      ]
+    }
+  ],
+  "claim_mapping": {
+    "openid": [ "sub" ],
+    "email": [ "email", "email_verified" ],
+    "profile": [ "name", "nickname" ],
+    "groups": ["groups"]
+  },
+  "cookies":{
+    "keys": [
+      "5298099a779da67d6c46855e6400799a"
+    ]
+  },
+  "jwks": [
+    {
+      "use": "sig",
+      "kty": "EC",
+      "kid": "zasEIDAu-yurYBO20Oi1L40BQRI2M1pFBMNswz9UHl0",
+      "crv": "P-256",
+      "alg": "ES256",
+      "x": "GoP0tL-RzlxMYFFNFalFnpaiSdODRqrmQ6Vc6Pv4lLg",
+      "y": "yIwUO7qnLsBSKxNNJ34SIcbgPjcfISxf4kJuBNBNOXA"
+    }
+  ]
+}

--- a/config/oidc-users.json
+++ b/config/oidc-users.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "admin",
+    "email": "admin@not.nrc.no",
+    "email_verified": true,
+    "name": "Admin",
+    "password": "123",
+    "groups": []
+  }
+]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: core
+    ports:
+      - "5432:5432"
+  oidc:
+    image: qlik/simple-oidc-provider
+    environment:
+      USERS: '[{"id": "1", "email": "test@example.com", "password": "password"}]'
+      CLIENTS: '[{"id": "test", "redirect_uris": ["http://localhost:3333/callback"]}]'
+    ports:
+      - "9000:9000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,10 +7,70 @@ services:
       POSTGRES_DB: core
     ports:
       - "5432:5432"
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
+    ports:
+      - "4180:4180"
+    restart: on-failure
+    depends_on:
+      - oidc
+    command:
+      - /bin/oauth2-proxy
+      - --cookie-secret=5bbca15ead8e545ad4ad262b60faf127
+      - --whitelist-domain=localhost:10000
+      - --http-address=0.0.0.0:4180
+      - --client-id=foo
+      - --client-secret=bar
+      - --email-domain=*
+      - --upstream=static://200
+      - --provider=oidc
+      - --provider-display-name="Oidc"
+      - --client-id=foo
+      - --client-secret=bar
+      - --scope=openid email profile groups
+      - --redirect-url=https://localhost:10000/oauth2/callback
+      - --cookie-secure=true
+      - --cookie-samesite=lax
+      - --cookie-csrf-per-request=true
+      - --cookie-csrf-expire=5m
+      - --cookie-refresh=5m
+      - --email-domain=*
+      - --oidc-issuer-url=https://localhost:10000
+      - --insecure-oidc-skip-issuer-verification=true
+      - --skip-oidc-discovery=true
+      - --skip-provider-button=true
+      - --oidc-jwks-url=http://oidc:9000/certs
+      - --login-url=https://localhost:10000/auth
+      - --redeem-url=http://oidc:9000/token
+      - --profile-url=http://oidc:9000/me
+      - --pass-access-token=true
+      - --pass-authorization-header=true
+      - --reverse-proxy=true
+      - --set-authorization-header=true
+      - --set-xauthrequest=true
   oidc:
     image: qlik/simple-oidc-provider
+    volumes:
+      - ./config/oidc-config.json:/etc/config.json
+      - ./config/oidc-users.json:/etc/users.json
     environment:
-      USERS: '[{"id": "1", "email": "test@example.com", "password": "password"}]'
-      CLIENTS: '[{"id": "test", "redirect_uris": ["http://localhost:3333/callback"]}]'
+      REDIRECTS: https://oauth2.core.dev:10000/oauth2/callback
+      CONFIG_FILE: /etc/config.json
+      USERS_FILE: /etc/users.json
+    healthcheck:
+      test: curl http://localhost/.well-known/openid-configuration
     ports:
       - "9000:9000"
+  envoy:
+    image: envoyproxy/envoy:v1.20-latest
+    depends_on:
+      - oauth2-proxy
+      - oidc
+    ports:
+      - "10000:10000"
+    volumes:
+      - ./config/envoy.yaml:/etc/envoy/envoy.yaml
+      - ./config/certs/tls.key:/etc/envoy/certs/tls.key
+      - ./config/certs/tls.crt:/etc/envoy/certs/tls.crt
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/scripts/create-local-tls-certificate.sh
+++ b/scripts/create-local-tls-certificate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install the local CA
+mkcert -install
+
+# Generate the certificate
+mkcert -cert-file config/certs/tls.crt -key-file config/certs/tls.key core.dev "*.core.dev" localhost 127.0.0.1 ::1


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-122
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Created a docker compose file for starting db and oidc servers for local development.
Added scripts for the `core-api` project to run docker compose commands + a `local-serve` command concatenating `up` and `serve`.

Note this PR is based on the backend skeleton branch, which wasn't merged yet.
Also, these dependencies are not being used yet, so I configured them in a very basic way to delay decisions until they can be more specific.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
`npx nx run core-api:local-serve` should start the db and oidc containers and then serve the application.
`npx nx run core:api:compose:up` and `npx nx run core:api:compose:down` should do compose ups and downs respectively.

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
No