### PR TITLE
Build db so migrations exist in a directory

### DIFF
--- a/libs/db/project.json
+++ b/libs/db/project.json
@@ -3,6 +3,17 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/db/src",
   "projectType": "library",
-  "targets": {},
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/db",
+        "tsConfig": "libs/db/tsconfig.lib.json",
+        "main": "libs/db/src/index.ts",
+        "assets": ["libs/db/*.md", "libs/db/migrations/*.ts"]
+      }
+    }
+  },
   "tags": []
 }


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-#
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
Previous pr removed the build step from all libs. db lib needs to be built so that migrations are stored in a directory that they can be ran from.