### PR TITLE
refactor(api): Pluralise resources and tables

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,1 +1,0 @@
-libs/db/migrations

--- a/apps/core-api-e2e/src/core-api/prm/participant.test.ts
+++ b/apps/core-api-e2e/src/core-api/prm/participant.test.ts
@@ -168,10 +168,10 @@ const participantDefinitionWithIds = {
   ),
 };
 
-describe('POST /api/prm/participant', () => {
+describe('POST /api/prm/participants', () => {
   it('should create a participant with every field', async () => {
     const res = await axiosInstance.post(
-      `/api/prm/participant`,
+      `/api/prm/participants`,
       participantDefinitionWithEveryField,
     );
 
@@ -183,7 +183,7 @@ describe('POST /api/prm/participant', () => {
 
   it('should create a participant with some fields', async () => {
     const res = await axiosInstance.post(
-      `/api/prm/participant`,
+      `/api/prm/participants`,
       participantDefinitionWithSomeFields,
     );
 
@@ -196,7 +196,7 @@ describe('POST /api/prm/participant', () => {
   // Enable with validation ticket
   it.skip('should return an error when creating a participant with missing required fields', async () => {
     const res = await axiosInstance.post(
-      `/api/prm/participant`,
+      `/api/prm/participants`,
       participantDefinitionWithMissingRequiredFields,
     );
 
@@ -215,7 +215,7 @@ describe('POST /api/prm/participant', () => {
   // Enable with validation ticket
   it.skip('should return an error when creating a participant with invalid fields', async () => {
     const res = await axiosInstance.post(
-      `/api/prm/participant`,
+      `/api/prm/participants`,
       participantDefinitionWithInvalidFields,
     );
     expect(res.status).toBe(400);
@@ -227,7 +227,7 @@ describe('POST /api/prm/participant', () => {
 
   // Enable with validation ticket
   it.skip('should strip unknown fields when creating a participant', async () => {
-    const res = await axiosInstance.post(`/api/prm/participant`, {
+    const res = await axiosInstance.post(`/api/prm/participants`, {
       ...participantDefinitionWithEveryField,
       unknownField: faker.word.noun(),
     });
@@ -239,7 +239,7 @@ describe('POST /api/prm/participant', () => {
   // Currently it doesn't strip ids, instead overwriting them in the db layer
   it('should strip ids when sent in the request body', async () => {
     const res = await axiosInstance.post(
-      `/api/prm/participant`,
+      `/api/prm/participants`,
       participantDefinitionWithIds,
     );
 

--- a/apps/core-api-e2e/src/core-api/user.spec.ts
+++ b/apps/core-api-e2e/src/core-api/user.spec.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
-describe('GET /api/me', () => {
+describe('GET /api/users/me', () => {
   it('should return the authenticated user', async () => {
-    const res = await axios.get(`/api/me`);
+    const res = await axios.get(`/api/users/me`);
 
     expect(res.status).toBe(200);
 

--- a/apps/core-api/src/controllers/user.controller.ts
+++ b/apps/core-api/src/controllers/user.controller.ts
@@ -6,7 +6,7 @@ import * as UserService from '../services/user.service';
 
 const router = Router();
 
-router.get('/me', async (req, res, next) => {
+router.get('/users/me', async (req, res, next) => {
   try {
     if (req.user) {
       const user = UserSchema.parse(req.user);
@@ -19,7 +19,7 @@ router.get('/me', async (req, res, next) => {
   }
 });
 
-router.get('/user', async (req, res, next) => {
+router.get('/users', async (req, res, next) => {
   try {
     const { startIndex, limit } = PaginationSchema.parse(req.query);
     const users = await UserService.list(startIndex, limit);

--- a/apps/core-frontend/src/components/Navigation.tsx
+++ b/apps/core-frontend/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 export const Navigation: React.FC = () => {
   return (
     <HStack>
-      <Link to="/prm/participant">Participants</Link>
+      <Link to="/prm/participants">Participants</Link>
     </HStack>
   );
 };

--- a/apps/core-frontend/src/routes.tsx
+++ b/apps/core-frontend/src/routes.tsx
@@ -42,7 +42,7 @@ export const router = createBrowserRouter([
         loader: editEntityLoader,
       },
       {
-        path: '/user',
+        path: '/users',
         element: <div>User</div>,
       },
     ],

--- a/libs/clients/src/lib/user.client.ts
+++ b/libs/clients/src/lib/user.client.ts
@@ -8,7 +8,7 @@ export class UserClient extends BaseClient<User> {
   }
 
   async getMe(): Promise<User> {
-    const res = await super.get('/me');
+    const res = await super.get('/users/me');
     return UserSchema.parse(res.data);
   }
 }

--- a/libs/db/migrations/20240423103743_pluralise-table-names.ts
+++ b/libs/db/migrations/20240423103743_pluralise-table-names.ts
@@ -1,0 +1,43 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.renameTable('entity', 'entities');
+  await knex.schema.renameTable('person', 'persons');
+  await knex.schema.renameTable('participant', 'participants');
+  await knex.schema.renameTable(
+    'participant_disability',
+    'participant_disabilities',
+  );
+  await knex.schema.renameTable(
+    'participant_identification',
+    'participant_identifications',
+  );
+  await knex.schema.renameTable(
+    'participant_contact_detail',
+    'participant_contact_details',
+  );
+  await knex.schema.renameTable('nationality', 'nationalities');
+  await knex.schema.renameTable('language', 'languages');
+  await knex.schema.renameTable('comment', 'comments');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.renameTable('entities', 'entity');
+  await knex.schema.renameTable('persons', 'person');
+  await knex.schema.renameTable('participants', 'participant');
+  await knex.schema.renameTable(
+    'participant_disabilities',
+    'participant_disability',
+  );
+  await knex.schema.renameTable(
+    'participant_identifications',
+    'participant_identification',
+  );
+  await knex.schema.renameTable(
+    'participant_contact_details',
+    'participant_contact_detail',
+  );
+  await knex.schema.renameTable('nationalities', 'nationality');
+  await knex.schema.renameTable('languages', 'language');
+  await knex.schema.renameTable('comments', 'comment');
+}

--- a/libs/db/seeds/common/languages.ts
+++ b/libs/db/seeds/common/languages.ts
@@ -10,10 +10,10 @@ export async function seed(knex: Knex): Promise<void> {
   ];
 
   // Upsert all rows in languages
-  await knex('language').insert(languages).onConflict('iso_code').merge();
+  await knex('languages').insert(languages).onConflict('iso_code').merge();
 
   // Disable any rows not in languages
-  await knex('language')
+  await knex('languages')
     .whereNotIn(
       'iso_code',
       languages.map((lang) => lang.isoCode),

--- a/libs/db/seeds/common/nationalities.ts
+++ b/libs/db/seeds/common/nationalities.ts
@@ -10,13 +10,13 @@ export async function seed(knex: Knex): Promise<void> {
   ];
 
   // Upsert all rows in nationalities
-  await knex('nationality')
+  await knex('nationalities')
     .insert(nationalities)
     .onConflict('iso_code')
     .merge();
 
   // Disable any rows not in nationalities
-  await knex('nationality')
+  await knex('nationalities')
     .whereNotIn(
       'iso_code',
       nationalities.map((lang) => lang.isoCode),

--- a/libs/models/src/lib/prm/entity.model.ts
+++ b/libs/models/src/lib/prm/entity.model.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
 export enum EntityType {
-  Participant = 'participant',
+  Participant = 'participants',
 }
 export const EntityTypeSchema = z.nativeEnum(EntityType);

--- a/libs/prm-engine/src/lib/stores/participant.store.test.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.test.ts
@@ -111,27 +111,27 @@ const buildQueries =
         expect(query.sql).toEqual('BEGIN;');
         query.response([]);
       },
-      // person
+      // persons
       () => {
-        expect(query.sql).toEqual(`insert into "person" ("id") values ($1)`);
+        expect(query.sql).toEqual(`insert into "persons" ("id") values ($1)`);
         query.response([]);
       },
-      // entity
+      // entities
       () => {
-        expect(query.sql).toEqual(`insert into "entity" ("id") values ($1)`);
+        expect(query.sql).toEqual(`insert into "entities" ("id") values ($1)`);
         query.response([]);
       },
-      // participant
+      // participants
       () => {
         expect(query.sql).toEqual(
-          `insert into "participant" ("consent_gdpr", "consent_referral", "contact_means_comment", "date_of_birth", "displacement_status", "engagement_context", "entity_id", "first_name", "id", "last_name", "middle_name", "mother_name", "native_name", "nrc_id", "person_id", "preferred_contact_means", "preferred_name", "residence", "sex") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+          `insert into "participants" ("consent_gdpr", "consent_referral", "contact_means_comment", "date_of_birth", "displacement_status", "engagement_context", "entity_id", "first_name", "id", "last_name", "middle_name", "mother_name", "native_name", "nrc_id", "person_id", "preferred_contact_means", "preferred_name", "residence", "sex") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
         );
         query.response([]);
       },
-      // participant_disability
+      // participant_disabilities
       () => {
         expect(query.sql).toEqual(
-          `insert into "participant_disability" ("disability_cognition_level", "disability_communication_level", "disability_hearing_level", "disability_mobility_level", "disability_pwd_comment", "disability_selfcare_level", "disability_vision_level", "has_disability_cognition", "has_disability_communication", "has_disability_hearing", "has_disability_mobility", "has_disability_pwd", "has_disability_selfcare", "has_disability_vision", "has_medical_condition", "is_child_at_risk", "is_elder_at_risk", "is_lactating", "is_pregnant", "is_separated_child", "is_single_parent", "is_woman_at_risk", "needs_legal_physical_protection", "participant_id", "vulnerability_comments") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)`,
+          `insert into "participant_disabilities" ("disability_cognition_level", "disability_communication_level", "disability_hearing_level", "disability_mobility_level", "disability_pwd_comment", "disability_selfcare_level", "disability_vision_level", "has_disability_cognition", "has_disability_communication", "has_disability_hearing", "has_disability_mobility", "has_disability_pwd", "has_disability_selfcare", "has_disability_vision", "has_medical_condition", "is_child_at_risk", "is_elder_at_risk", "is_lactating", "is_pregnant", "is_separated_child", "is_single_parent", "is_woman_at_risk", "needs_legal_physical_protection", "participant_id", "vulnerability_comments") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)`,
         );
         query.response([]);
       },
@@ -145,7 +145,7 @@ const buildQueries =
       // languages retrieval
       () => {
         expect(query.sql).toEqual(
-          `select * from "language" where "iso_code" in ($1)`,
+          `select * from "languages" where "iso_code" in ($1)`,
         );
         query.response([
           {
@@ -164,7 +164,7 @@ const buildQueries =
       // nationalities retrieval
       () => {
         expect(query.sql).toEqual(
-          `select * from "nationality" where "iso_code" in ($1)`,
+          `select * from "nationalities" where "iso_code" in ($1)`,
         );
         query.response([
           {
@@ -176,14 +176,14 @@ const buildQueries =
       // contact details
       () => {
         expect(query.sql).toEqual(
-          `insert into "participant_contact_detail" ("clean_value", "contact_detail_type", "id", "participant_id", "raw_value") values ($1, $2, $3, $4, $5)`,
+          `insert into "participant_contact_details" ("clean_value", "contact_detail_type", "id", "participant_id", "raw_value") values ($1, $2, $3, $4, $5)`,
         );
         query.response([]);
       },
-      // identification
+      // identifications
       () => {
         expect(query.sql).toEqual(
-          `insert into "participant_identification" ("id", "identification_number", "identification_type", "is_primary", "participant_id") values ($1, $2, $3, $4, $5)`,
+          `insert into "participant_identifications" ("id", "identification_number", "identification_type", "is_primary", "participant_id") values ($1, $2, $3, $4, $5)`,
         );
         query.response([]);
       },

--- a/libs/prm-engine/src/lib/stores/participant.store.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.ts
@@ -31,11 +31,11 @@ const create = async (
 
   const result = await db.transaction(async (trx) => {
     try {
-      await trx('person').insert({ id: personId });
+      await trx('persons').insert({ id: personId });
 
-      await trx('entity').insert({ id: entityId });
+      await trx('entities').insert({ id: entityId });
 
-      await trx('participant').insert({
+      await trx('participants').insert({
         ...participantDetails,
         id: participantId,
         personId,
@@ -43,7 +43,7 @@ const create = async (
       });
 
       if (disabilities) {
-        await trx('participant_disability').insert({
+        await trx('participant_disabilities').insert({
           ...disabilities,
           participantId,
         });
@@ -57,7 +57,7 @@ const create = async (
             participantId,
           })),
         );
-        languagesResult = await trx('language').whereIn(
+        languagesResult = await trx('languages').whereIn(
           'isoCode',
           languages.map((lang) => lang.isoCode),
         );
@@ -71,7 +71,7 @@ const create = async (
             participantId,
           })),
         );
-        nationalitiesResult = await trx('nationality').whereIn(
+        nationalitiesResult = await trx('nationalities').whereIn(
           'isoCode',
           nationalities.map((nat) => nat.isoCode),
         );
@@ -88,7 +88,7 @@ const create = async (
             }))
           : [];
       if (contactDetailsForDb.length > 0) {
-        await trx('participant_contact_detail').insert(contactDetailsForDb);
+        await trx('participant_contact_details').insert(contactDetailsForDb);
       }
 
       const identificationForDb =
@@ -100,7 +100,7 @@ const create = async (
             }))
           : [];
       if (identificationForDb.length > 0) {
-        await trx('participant_identification').insert(identificationForDb);
+        await trx('participant_identifications').insert(identificationForDb);
       }
 
       const createdParticipant = ParticipantSchema.parse({


### PR DESCRIPTION
## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
We agreed on naming API resources in plural form, so I adapted the existing resources (users and participants).
Also moved `/me` endpoint to `/users/me`
Renamed all db tables to use plural forms

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Start the app, and see the user data correctly

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
