### PR TITLE
Core24 199 prm client

### DIFF
--- a/apps/core-frontend/src/contexts/api.context.tsx
+++ b/apps/core-frontend/src/contexts/api.context.tsx
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import axios from 'axios';
 
 import { UserClient } from '@nrcno/core-clients';
 
@@ -9,10 +10,14 @@ export const ApiContext = createContext<ApiContextType | null>(null);
 export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const users = new UserClient({
+  const axiosInstance = axios.create({
     baseURL: '/api',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    withCredentials: true,
   });
-  users.client.interceptors.response.use(
+  axiosInstance.interceptors.response.use(
     (response) => {
       return response;
     },
@@ -23,6 +28,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({
       return error;
     },
   );
+  const users = new UserClient(axiosInstance);
   const clients = { users };
 
   return <ApiContext.Provider value={clients}>{children}</ApiContext.Provider>;

--- a/libs/clients/src/lib/base.client.test.ts
+++ b/libs/clients/src/lib/base.client.test.ts
@@ -1,7 +1,82 @@
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
 import { BaseClient } from './base.client';
 
 describe('coreClients', () => {
-  it('should create an instance', () => {
-    expect(new BaseClient({})).toBeTruthy();
+  let client: BaseClient;
+  let mock: any;
+
+  beforeEach(() => {
+    const axiosInstance = axios.create();
+    mock = new MockAdapter(axiosInstance);
+    client = new BaseClient(axiosInstance);
+
+    mock.onGet('/foo').reply(200, {
+      a: 1,
+    });
+
+    mock.onPost('/foo').reply(202, {
+      b: 2,
+    });
+
+    mock.onPut('/foo').reply(203, {
+      c: 3,
+    });
+
+    mock.onPatch('/foo').reply(204, {
+      d: 4,
+    });
+
+    mock.onDelete('/foo').reply(205, {
+      e: 5,
+    });
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('should get', async () => {
+    const res = await client.get('/foo');
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ a: 1 });
+    expect(mock.history.get.length).toBe(1);
+    expect(mock.history.get[0].url).toBe('/foo');
+  });
+
+  it('should post', async () => {
+    const res = await client.post('/foo', { a: 1 });
+    expect(res.status).toBe(202);
+    expect(res.data).toEqual({ b: 2 });
+    expect(mock.history.post.length).toBe(1);
+    expect(mock.history.post[0].url).toBe('/foo');
+    expect(mock.history.post[0].data).toBe('{"a":1}');
+  });
+
+  it('should put', async () => {
+    const res = await client.put('/foo', { a: 1 });
+    expect(res.status).toBe(203);
+    expect(res.data).toEqual({ c: 3 });
+    expect(mock.history.put.length).toBe(1);
+    expect(mock.history.put[0].url).toBe('/foo');
+    expect(mock.history.put[0].data).toBe('{"a":1}');
+  });
+
+  it('should patch', async () => {
+    const res = await client.patch('/foo', { a: 1 });
+    expect(res.status).toBe(204);
+    expect(res.data).toEqual({ d: 4 });
+    expect(mock.history.patch.length).toBe(1);
+    expect(mock.history.patch[0].url).toBe('/foo');
+    expect(mock.history.patch[0].data).toBe('{"a":1}');
+  });
+
+  it('should delete', async () => {
+    const res = await client.delete('/foo');
+    expect(res.status).toBe(205);
+    expect(res.data).toEqual({ e: 5 });
+    expect(mock.history.delete.length).toBe(1);
+    expect(mock.history.delete[0].url).toBe('/foo');
   });
 });

--- a/libs/clients/src/lib/base.client.ts
+++ b/libs/clients/src/lib/base.client.ts
@@ -27,7 +27,7 @@ interface IClient {
 }
 
 export class BaseClient implements IClient {
-  client: AxiosInstance;
+  private client: AxiosInstance;
 
   constructor(instance?: AxiosInstance, config?: ClientConfig) {
     if (instance) {

--- a/libs/clients/src/lib/base.client.ts
+++ b/libs/clients/src/lib/base.client.ts
@@ -1,31 +1,35 @@
 import axios, {
-  AxiosError,
+  CreateAxiosDefaults,
   AxiosInstance,
-  AxiosRequestConfig,
   AxiosResponse,
 } from 'axios';
 
-export type ClientConfig<Data> = AxiosRequestConfig<Data>;
+export type ClientConfig = CreateAxiosDefaults;
 
-type ClientRequest<Data> = (
-  url: string,
-  params?: Partial<Data>,
-) => Promise<
-  AxiosResponse<Data, ClientConfig<Data>> | AxiosError<Data, ClientConfig<Data>>
->;
-
-interface IClient<Data> {
-  get: ClientRequest<Data>;
-  post: ClientRequest<Data>;
-  put: ClientRequest<Data>;
-  patch: ClientRequest<Data>;
-  delete: ClientRequest<Data>;
+interface IClient {
+  get: (url: string, params?: any) => Promise<AxiosResponse<unknown>>;
+  post: (
+    url: string,
+    data?: any,
+    params?: any,
+  ) => Promise<AxiosResponse<unknown>>;
+  put: (
+    url: string,
+    data?: any,
+    params?: any,
+  ) => Promise<AxiosResponse<unknown>>;
+  patch: (
+    url: string,
+    data?: any,
+    params?: any,
+  ) => Promise<AxiosResponse<unknown>>;
+  delete: (url: string, params?: any) => Promise<AxiosResponse<unknown>>;
 }
 
-export class BaseClient<Data> implements IClient<Data> {
+export class BaseClient implements IClient {
   client: AxiosInstance;
 
-  constructor({ baseURL, ...config }: ClientConfig<Data>) {
+  constructor({ baseURL, ...config }: ClientConfig) {
     this.client = axios.create({
       baseURL,
       headers: {
@@ -36,23 +40,35 @@ export class BaseClient<Data> implements IClient<Data> {
     });
   }
 
-  async get(url: string, params?: Partial<Data>) {
+  async get(url: string, params?: any): Promise<AxiosResponse<unknown>> {
     return this.client.get(url, params);
   }
 
-  async post(url: string, params?: Partial<Data>) {
+  async post(
+    url: string,
+    data?: any,
+    params?: any,
+  ): Promise<AxiosResponse<unknown>> {
     return this.client.post(url, params);
   }
 
-  async put(url: string, params?: Partial<Data>) {
+  async put(
+    url: string,
+    data?: any,
+    params?: any,
+  ): Promise<AxiosResponse<unknown>> {
     return this.client.put(url, params);
   }
 
-  async patch(url: string, params?: Partial<Data>) {
+  async patch(
+    url: string,
+    data?: any,
+    params?: any,
+  ): Promise<AxiosResponse<unknown>> {
     return this.client.patch(url, params);
   }
 
-  async delete(url: string, params?: Partial<Data>) {
+  async delete(url: string, params?: any): Promise<AxiosResponse<unknown>> {
     return this.client.delete(url, params);
   }
 }

--- a/libs/clients/src/lib/base.client.ts
+++ b/libs/clients/src/lib/base.client.ts
@@ -29,15 +29,26 @@ interface IClient {
 export class BaseClient implements IClient {
   client: AxiosInstance;
 
-  constructor({ baseURL, ...config }: ClientConfig) {
-    this.client = axios.create({
-      baseURL,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      withCredentials: true,
-      ...config,
-    });
+  constructor(instance?: AxiosInstance, config?: ClientConfig) {
+    if (instance) {
+      this.client = instance;
+      return;
+    }
+
+    if (config) {
+      const { baseURL, ...otherConfig } = config;
+      this.client = axios.create({
+        baseURL,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        withCredentials: true,
+        ...otherConfig,
+      });
+      return;
+    }
+
+    throw new Error('No instance or config provided');
   }
 
   async get(url: string, params?: any): Promise<AxiosResponse<unknown>> {
@@ -49,7 +60,7 @@ export class BaseClient implements IClient {
     data?: any,
     params?: any,
   ): Promise<AxiosResponse<unknown>> {
-    return this.client.post(url, params);
+    return this.client.post(url, data, params);
   }
 
   async put(
@@ -57,7 +68,7 @@ export class BaseClient implements IClient {
     data?: any,
     params?: any,
   ): Promise<AxiosResponse<unknown>> {
-    return this.client.put(url, params);
+    return this.client.put(url, data, params);
   }
 
   async patch(
@@ -65,7 +76,7 @@ export class BaseClient implements IClient {
     data?: any,
     params?: any,
   ): Promise<AxiosResponse<unknown>> {
-    return this.client.patch(url, params);
+    return this.client.patch(url, data, params);
   }
 
   async delete(url: string, params?: any): Promise<AxiosResponse<unknown>> {

--- a/libs/clients/src/lib/prm/participant.client.test.ts
+++ b/libs/clients/src/lib/prm/participant.client.test.ts
@@ -1,10 +1,99 @@
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import { faker } from '@faker-js/faker';
+import { ZodError } from 'zod';
+import { ulid } from 'ulidx';
+
+import { ParticipantDefinition } from '@nrcno/core-models';
+
 import { ParticipantClient } from './participant.client';
 
-describe('ParticipantClient', () => {
-  it('should create an instance', () => {
-    const client = new ParticipantClient(undefined, {
-      baseURL: 'http://localhost:3000',
+describe('PRM Participant client', () => {
+  let client: ParticipantClient;
+  let mock: any;
+
+  beforeEach(() => {
+    const axiosInstance = axios.create();
+    mock = new MockAdapter(axiosInstance);
+    client = new ParticipantClient(axiosInstance);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe('create', () => {
+    it('should create a participant', async () => {
+      const participantDefinition = {
+        consentGdpr: faker.datatype.boolean(),
+        consentReferral: faker.datatype.boolean(),
+        languages: [],
+        nationalities: [],
+        contactDetails: [],
+        identification: [],
+      };
+
+      const participant = {
+        id: ulid(),
+        ...participantDefinition,
+      };
+
+      mock.onPost('/participants').reply(201, participant);
+
+      const res = await client.create(participantDefinition);
+
+      expect(res).toEqual(participant);
+      expect(mock.history.post.length).toBe(1);
+      expect(mock.history.post[0].url).toBe('/participants');
+      expect(mock.history.post[0].data).toBe(
+        JSON.stringify(participantDefinition),
+      );
     });
-    expect(client).toBeTruthy();
+
+    it('should fail with an invalid participant definition', async () => {
+      const participantDefinition = {
+        firstName: faker.person.firstName(),
+      };
+
+      await expect(
+        client.create(participantDefinition as ParticipantDefinition),
+      ).rejects.toThrow(expect.any(ZodError));
+    });
+
+    it('should fail when receiving an invalid response from the api', () => {
+      const participantDefinition = {
+        consentGdpr: faker.datatype.boolean(),
+        consentReferral: faker.datatype.boolean(),
+        languages: [],
+        nationalities: [],
+        contactDetails: [],
+        identification: [],
+      };
+
+      mock.onPost('/participants').reply(201, {
+        foo: 'bar',
+      });
+
+      expect(client.create(participantDefinition)).rejects.toThrow(
+        expect.any(ZodError),
+      );
+    });
+
+    it('should fail if the api returns an error', () => {
+      const participantDefinition = {
+        consentGdpr: faker.datatype.boolean(),
+        consentReferral: faker.datatype.boolean(),
+        languages: [],
+        nationalities: [],
+        contactDetails: [],
+        identification: [],
+      };
+
+      mock.onPost('/participants').reply(400);
+
+      expect(client.create(participantDefinition)).rejects.toThrow(
+        'Request failed with status code 400',
+      );
+    });
   });
 });

--- a/libs/clients/src/lib/prm/participant.client.test.ts
+++ b/libs/clients/src/lib/prm/participant.client.test.ts
@@ -2,7 +2,9 @@ import { ParticipantClient } from './participant.client';
 
 describe('ParticipantClient', () => {
   it('should create an instance', () => {
-    const client = new ParticipantClient({ baseURL: 'http://localhost:3000' });
+    const client = new ParticipantClient(undefined, {
+      baseURL: 'http://localhost:3000',
+    });
     expect(client).toBeTruthy();
   });
 });

--- a/libs/clients/src/lib/prm/participant.client.ts
+++ b/libs/clients/src/lib/prm/participant.client.ts
@@ -1,4 +1,9 @@
-import { Participant, ParticipantDefinition } from '@nrcno/core-models';
+import {
+  Participant,
+  ParticipantDefinition,
+  ParticipantDefinitionSchema,
+  ParticipantSchema,
+} from '@nrcno/core-models';
 
 import { BaseClient, ClientConfig } from '../base.client';
 
@@ -10,6 +15,13 @@ export class ParticipantClient extends BaseClient {
   create = async (
     participantDefinition: ParticipantDefinition,
   ): Promise<Participant> => {
-    throw new Error('Not implemented');
+    const validatedParticipantDefinition = ParticipantDefinitionSchema.parse(
+      participantDefinition,
+    );
+    const response = await this.post(
+      '/participants',
+      validatedParticipantDefinition,
+    );
+    return ParticipantSchema.parse(response.data);
   };
 }

--- a/libs/clients/src/lib/prm/participant.client.ts
+++ b/libs/clients/src/lib/prm/participant.client.ts
@@ -2,8 +2,8 @@ import { Participant, ParticipantDefinition } from '@nrcno/core-models';
 
 import { BaseClient, ClientConfig } from '../base.client';
 
-export class ParticipantClient extends BaseClient<Participant> {
-  constructor({ baseURL }: ClientConfig<Participant>) {
+export class ParticipantClient extends BaseClient {
+  constructor({ baseURL }: ClientConfig) {
     super({ baseURL });
   }
 

--- a/libs/clients/src/lib/prm/participant.client.ts
+++ b/libs/clients/src/lib/prm/participant.client.ts
@@ -1,3 +1,5 @@
+import { AxiosInstance } from 'axios';
+
 import {
   Participant,
   ParticipantDefinition,
@@ -8,8 +10,8 @@ import {
 import { BaseClient, ClientConfig } from '../base.client';
 
 export class ParticipantClient extends BaseClient {
-  constructor({ baseURL }: ClientConfig) {
-    super({ baseURL });
+  constructor(instance?: AxiosInstance, config?: ClientConfig) {
+    super(instance, config);
   }
 
   create = async (

--- a/libs/clients/src/lib/prm/prm.client.test.ts
+++ b/libs/clients/src/lib/prm/prm.client.test.ts
@@ -2,7 +2,9 @@ import { PrmClient } from './prm.client';
 
 describe('PrmClient', () => {
   it('should create an instance', () => {
-    const client = new PrmClient({ baseURL: 'http://localhost:3000' });
+    const client = new PrmClient(undefined, {
+      baseURL: 'http://localhost:3000',
+    });
     expect(client).toBeTruthy();
   });
 });

--- a/libs/clients/src/lib/prm/prm.client.ts
+++ b/libs/clients/src/lib/prm/prm.client.ts
@@ -1,3 +1,5 @@
+import { AxiosInstance } from 'axios';
+
 import { ClientConfig } from '../base.client';
 
 import { ParticipantClient } from './participant.client';
@@ -5,8 +7,8 @@ import { ParticipantClient } from './participant.client';
 export class PrmClient {
   private participantClient: ParticipantClient;
 
-  constructor({ baseURL }: ClientConfig<any>) {
-    this.participantClient = new ParticipantClient({ baseURL });
+  constructor(instance?: AxiosInstance, config?: ClientConfig) {
+    this.participantClient = new ParticipantClient(instance, config);
   }
 
   get participant() {

--- a/libs/clients/src/lib/user.client.ts
+++ b/libs/clients/src/lib/user.client.ts
@@ -2,8 +2,8 @@ import { User, UserSchema } from '@nrcno/core-models';
 
 import { BaseClient, ClientConfig } from './base.client';
 
-export class UserClient extends BaseClient<User> {
-  constructor({ baseURL }: ClientConfig<User>) {
+export class UserClient extends BaseClient {
+  constructor({ baseURL }: ClientConfig) {
     super({ baseURL });
   }
 

--- a/libs/clients/src/lib/user.client.ts
+++ b/libs/clients/src/lib/user.client.ts
@@ -1,10 +1,12 @@
+import { AxiosInstance } from 'axios';
+
 import { User, UserSchema } from '@nrcno/core-models';
 
 import { BaseClient, ClientConfig } from './base.client';
 
 export class UserClient extends BaseClient {
-  constructor({ baseURL }: ClientConfig) {
-    super({ baseURL });
+  constructor(instance?: AxiosInstance, config?: ClientConfig) {
+    super(instance, config);
   }
 
   async getMe(): Promise<User> {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@vitejs/plugin-react": "^4.2.0",
     "@vitest/coverage-v8": "^1.0.4",
     "@vitest/ui": "^1.3.1",
+    "axios-mock-adapter": "^1.22.0",
     "cypress": "^13.6.6",
     "eslint": "~8.48.0",
     "eslint-config-prettier": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6519,6 +6519,14 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.9.0.tgz#b18971494551ab39d4ff5f7d4c6411bd20cc7c2a"
   integrity sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==
 
+axios-mock-adapter@^1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz#0f3e6be0fc9b55baab06f2d49c0b71157e7c053d"
+  integrity sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
+
 axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -10500,6 +10508,11 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-199
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
* Refactor the api clients to accept and axios instance as an argument. This was done here for testing, but the idea is that the app will define a single axios instance that will be shared across client.
* Remove data types from the base client
* Fix base client methods for requests accepting a body
* Implement prm participant client's create method
* Add tests for base client

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
