### PR TITLE
fix(ci): Updated actions versions to use node 20 and get rid of deprecation warnings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: ./
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Docker Login
         uses: azure/docker-login@v1
@@ -33,7 +33,7 @@ jobs:
           password: ${{secrets.ACR_PASSWORD}}
 
       - name: Configure Azure credentials
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{secrets.AZURE_CREDENTIALS}}
 
@@ -95,15 +95,15 @@ jobs:
           echo "Deploying to: ${{ github.event.inputs.environment || 'dev' }}"
 
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Azure Credentials
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{secrets.AZURE_CREDENTIALS}}
 
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{vars.TERRAFORM_VERSION}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       # Cache node_modules
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'


### PR DESCRIPTION
## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
We had some deprecation warnings in the builds, because we were using some older versions of actions that were using deprecated versions of node.
`azure/docker-login@v1` is still using node 16, but there's no newer version available

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
No more warnings in CI / CD builds (actually only one related to docker-login as mentioned above)

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
