### PR TITLE
task(db): Added created and updated timestamps to participant tables

### DIFF
--- a/libs/db/migrations/20240507102924_add-timestamps.ts
+++ b/libs/db/migrations/20240507102924_add-timestamps.ts
@@ -1,0 +1,47 @@
+import type { Knex } from 'knex';
+
+const tables = [
+  'participants',
+  'participant_disabilities',
+  'participant_identifications',
+  'participant_contact_details',
+  'participant_nationalities',
+  'participant_languages',
+];
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE OR REPLACE FUNCTION update_updated_at_column()
+    RETURNS TRIGGER AS $$
+    BEGIN
+       NEW.updated_at = current_timestamp(3);
+       RETURN NEW;
+    END;
+    $$ language 'plpgsql';
+  `);
+
+  for (const table of tables) {
+    await knex.schema.table(table, (table) => {
+      table.timestamp('created_at', { precision: 3 }).defaultTo(knex.fn.now(3));
+      table.timestamp('updated_at', { precision: 3 }).defaultTo(knex.fn.now(3));
+    });
+
+    await knex.raw(`
+      CREATE TRIGGER update_timestamp
+      BEFORE UPDATE ON ${table}
+      FOR EACH ROW
+      EXECUTE PROCEDURE update_updated_at_column();
+    `);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP FUNCTION update_updated_at_column CASCADE;`);
+
+  for (const table of tables) {
+    await knex.schema.table(table, (table) => {
+      table.dropColumn('created_at');
+      table.dropColumn('updated_at');
+    });
+  }
+}


### PR DESCRIPTION
Related to Jira ticket: JIRA-CORE24-253
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Database migration adding `created_at` and `updated_at` columns to all participant tables.
For updating `updated_at` a stored procedure was created, and a trigger added to each table. (Which seems to be the postgresql way).

Since we are not including these properties in the models and we use the schema to parse the results we get from the database, then they are removed from the objects managed by the application, and shouldn't have any impact on it.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Check in the db that the new columns are available and populated

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
