### PR TITLE
[CORE24-253] feat(participants): list participants with pagination

### DIFF
--- a/apps/core-api-e2e/src/core-api/prm/participant.test.ts
+++ b/apps/core-api-e2e/src/core-api/prm/participant.test.ts
@@ -2,7 +2,10 @@ import axios from 'axios';
 import { faker } from '@faker-js/faker';
 import { ulid } from 'ulidx';
 
-import { ParticipantGenerator } from '@nrcno/core-test-utils';
+import {
+  IdentificationGenerator,
+  ParticipantGenerator,
+} from '@nrcno/core-test-utils';
 import {
   ParticipantSchema,
   ParticipantDefinition,
@@ -107,6 +110,7 @@ const participantDefinitionWithIds = {
   ),
 };
 
+// TODO: make tests independent by running them against a clean database
 describe('Participants', () => {
   describe('POST /api/prm/participants', () => {
     it('should create a participant with every field', async () => {
@@ -230,6 +234,79 @@ describe('Participants', () => {
       const response = await axiosInstance.get(`/api/prm/participants/invalid`);
 
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/prm/participants', () => {
+    const primaryIdentification = IdentificationGenerator.generateDefinition({
+      isPrimary: true,
+    });
+    const participantDefinition = ParticipantGenerator.generateDefinition({
+      identification: [primaryIdentification],
+    });
+    let participantId: string;
+    beforeAll(async () => {
+      const res = await axiosInstance.post(
+        `/api/prm/participants`,
+        participantDefinition,
+      );
+      participantId = res.data.id;
+    });
+
+    it('should return a list of participants', async () => {
+      const res = await axiosInstance.get(`/api/prm/participants`);
+
+      const expectedListItem = {
+        id: participantId,
+        firstName: participantDefinition.firstName,
+        lastName: participantDefinition.lastName,
+        dateOfBirth: participantDefinition.dateOfBirth?.toISOString(),
+        sex: participantDefinition.sex,
+        displacementStatus: participantDefinition.displacementStatus,
+        primaryIdentificationType: primaryIdentification.identificationType,
+        primaryIdentificationNumber: primaryIdentification.identificationNumber,
+        nationality: participantDefinition.nationalities[0].isoCode,
+        email: participantDefinition.contactDetails.emails[0].value,
+        phone: participantDefinition.contactDetails.phones[0].value,
+      };
+
+      expect(res.status).toBe(200);
+      expect(res.data).toEqual({
+        startIndex: 0,
+        pageSize: 50,
+        totalCount: expect.any(Number),
+        items: expect.arrayContaining([expectedListItem]),
+      });
+    });
+
+    it('should return a list of participants with pagination', async () => {
+      const res = await axiosInstance.get(
+        `/api/prm/participants?startIndex=1&pageSize=25`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.data).toEqual({
+        startIndex: 1,
+        pageSize: 25,
+        totalCount: expect.any(Number),
+        items: expect.arrayContaining([expect.objectContaining({})]),
+      });
+    });
+
+    it('should return an error if the startIndex is invalid', async () => {
+      const response = await axiosInstance.get(
+        `/api/prm/participants?startIndex=invalid`,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return an error if the pageSize is invalid', async () => {
+      const response = await axiosInstance.get(
+        `/api/prm/participants?pageSize=invalid`,
+      );
+
+      expect(response.status).toBe(400);
     });
   });
 

--- a/apps/core-api-e2e/src/core-api/prm/participant.test.ts
+++ b/apps/core-api-e2e/src/core-api/prm/participant.test.ts
@@ -265,7 +265,7 @@ describe('Participants', () => {
         displacementStatus: participantDefinition.displacementStatus,
         primaryIdentificationType: primaryIdentification.identificationType,
         primaryIdentificationNumber: primaryIdentification.identificationNumber,
-        nationality: participantDefinition.nationalities[0].isoCode,
+        nationality: participantDefinition.nationalities[0],
         email: participantDefinition.contactDetails.emails[0].value,
         phone: participantDefinition.contactDetails.phones[0].value,
       };

--- a/apps/core-api-e2e/src/core-api/prm/participant.test.ts
+++ b/apps/core-api-e2e/src/core-api/prm/participant.test.ts
@@ -274,7 +274,7 @@ describe('Participants', () => {
       expect(res.data).toEqual({
         startIndex: 0,
         pageSize: 50,
-        totalCount: expect.any(Number),
+        totalCount: expect.any(Number), // TODO: once tests are isolated, expect 1
         items: expect.arrayContaining([expectedListItem]),
       });
     });
@@ -288,7 +288,7 @@ describe('Participants', () => {
       expect(res.data).toEqual({
         startIndex: 1,
         pageSize: 25,
-        totalCount: expect.any(Number),
+        totalCount: expect.any(Number), // TODO: once tests are isolated, expect 1
         items: expect.arrayContaining([expect.objectContaining({})]),
       });
     });

--- a/apps/core-api/src/controllers/prm.controller.ts
+++ b/apps/core-api/src/controllers/prm.controller.ts
@@ -6,6 +6,9 @@ import {
   EntityIdSchema,
   getEntityDefinitionSchema,
   getEntityUpdateSchema,
+  PaginatedResponse,
+  EntityListItem,
+  PaginationSchema,
 } from '@nrcno/core-models';
 
 // This is exported for testing purposes (not great)
@@ -90,8 +93,41 @@ export const updateEntity = async (
   }
 };
 
+export const listEntities = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const entityType = EntityTypeSchema.safeParse(req.params.entityType);
+
+    if (entityType.success === false) {
+      res.sendStatus(404);
+      return;
+    }
+    const { startIndex, pageSize } = PaginationSchema.parse(req.query);
+
+    const prmService = PrmService[entityType.data];
+
+    const entities = await prmService.list(startIndex, pageSize);
+    const totalCount = await prmService.count();
+
+    const response: PaginatedResponse<EntityListItem> = {
+      startIndex,
+      pageSize,
+      totalCount,
+      items: entities,
+    };
+
+    res.status(200).json(response);
+  } catch (error) {
+    next(error);
+  }
+};
+
 const router = Router();
 router.post('/prm/:entityType', createEntity);
+router.get('/prm/:entityType', listEntities);
 router.get('/prm/:entityType/:entityId', getEntity);
 router.put('/prm/:entityType/:entityId', updateEntity);
 

--- a/apps/core-api/src/controllers/prm.controller.ts
+++ b/apps/core-api/src/controllers/prm.controller.ts
@@ -105,16 +105,16 @@ export const listEntities = async (
       res.sendStatus(404);
       return;
     }
-    const { startIndex, pageSize } = PaginationSchema.parse(req.query);
+    const pagination = PaginationSchema.parse(req.query);
 
     const prmService = PrmService[entityType.data];
 
-    const entities = await prmService.list(startIndex, pageSize);
+    const entities = await prmService.list(pagination);
     const totalCount = await prmService.count();
 
     const response: PaginatedResponse<EntityListItem> = {
-      startIndex,
-      pageSize,
+      startIndex: pagination.startIndex,
+      pageSize: pagination.pageSize,
       totalCount,
       items: entities,
     };

--- a/libs/models/src/lib/pagination.model.ts
+++ b/libs/models/src/lib/pagination.model.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const PaginationSchema = z.object({
   startIndex: z.coerce.number().int().min(0).optional().default(0),
-  pageSize: z.coerce.number().int().min(1).optional().default(100),
+  pageSize: z.coerce.number().int().min(1).optional().default(50),
 });
 
 export type Pagination = z.infer<typeof PaginationSchema>;

--- a/libs/prm-engine/src/lib/services/base.service.ts
+++ b/libs/prm-engine/src/lib/services/base.service.ts
@@ -1,5 +1,6 @@
 import {
   EntityType,
+  Pagination,
   Participant,
   ParticipantDefinition,
   ParticipantListItem,
@@ -18,7 +19,7 @@ export type PrmService<
   create: (entity: TDefinition) => Promise<TEntity>;
   get: (id: string) => Promise<TEntity | null>;
   update: (id: string, entity: TUpdateDefinition) => Promise<TEntity>;
-  list: (page?: number, pageSize?: number) => Promise<TEntityListItem[]>;
+  list: (pagination: Pagination) => Promise<TEntityListItem[]>;
 };
 
 export function getPrmService(
@@ -54,8 +55,8 @@ export function getPrmService(
     return Store.update(id, entity);
   };
 
-  const list = async (startIndex?: number, pageSize?: number) => {
-    return Store.list(startIndex, pageSize);
+  const list = async (pagination: Pagination) => {
+    return Store.list(pagination);
   };
 
   return { count, create, get, update, list };

--- a/libs/prm-engine/src/lib/services/base.service.ts
+++ b/libs/prm-engine/src/lib/services/base.service.ts
@@ -2,28 +2,45 @@ import {
   EntityType,
   Participant,
   ParticipantDefinition,
+  ParticipantListItem,
   ParticipantUpdate,
 } from '@nrcno/core-models';
 
 import { PrmStore } from '../stores';
 
-export type PrmService<TDefinition, TEntity, TUpdateDefinition> = {
+export type PrmService<
+  TDefinition,
+  TEntity,
+  TUpdateDefinition,
+  TEntityListItem,
+> = {
+  count: () => Promise<number>;
   create: (entity: TDefinition) => Promise<TEntity>;
   get: (id: string) => Promise<TEntity | null>;
   update: (id: string, entity: TUpdateDefinition) => Promise<TEntity>;
+  list: (page?: number, pageSize?: number) => Promise<TEntityListItem[]>;
 };
 
 export function getPrmService(
   entityType: EntityType.Participant,
-): PrmService<ParticipantDefinition, Participant, ParticipantUpdate>;
+): PrmService<
+  ParticipantDefinition,
+  Participant,
+  ParticipantUpdate,
+  ParticipantListItem
+>;
 export function getPrmService(
   entityType: EntityType,
-): PrmService<any, any, any> {
+): PrmService<any, any, any, any> {
   const Store = PrmStore[entityType];
 
   if (!Store) {
     throw new Error(`Entity type "${entityType}" is not supported`);
   }
+
+  const count = async () => {
+    return Store.count();
+  };
 
   const create = async (entity: any) => {
     return Store.create(entity);
@@ -37,5 +54,9 @@ export function getPrmService(
     return Store.update(id, entity);
   };
 
-  return { create, get, update };
+  const list = async (startIndex?: number, pageSize?: number) => {
+    return Store.list(startIndex, pageSize);
+  };
+
+  return { count, create, get, update, list };
 }

--- a/libs/prm-engine/src/lib/services/participant.service.ts
+++ b/libs/prm-engine/src/lib/services/participant.service.ts
@@ -2,6 +2,7 @@ import {
   ContactDetails,
   ContactDetailsDefinition,
   Identification,
+  Pagination,
   Participant,
   ParticipantDefinition,
   ParticipantListItem,
@@ -31,8 +32,8 @@ export const ParticipantService: PrmService<
     return ParticipantStore.get(id);
   },
 
-  list: async (startIndex?: number, pageSize?: number) => {
-    return ParticipantStore.list(startIndex, pageSize);
+  list: async (pagination: Pagination) => {
+    return ParticipantStore.list(pagination);
   },
 
   update: async (id: string, participant: ParticipantUpdate) => {

--- a/libs/prm-engine/src/lib/services/participant.service.ts
+++ b/libs/prm-engine/src/lib/services/participant.service.ts
@@ -4,6 +4,7 @@ import {
   Identification,
   Participant,
   ParticipantDefinition,
+  ParticipantListItem,
   ParticipantUpdate,
 } from '@nrcno/core-models';
 import { NotFoundError } from '@nrcno/core-errors';
@@ -15,14 +16,23 @@ import { PrmService } from './base.service';
 export const ParticipantService: PrmService<
   ParticipantDefinition,
   Participant,
-  ParticipantUpdate
+  ParticipantUpdate,
+  ParticipantListItem
 > = {
+  count: async () => {
+    return ParticipantStore.count();
+  },
+
   create: async (participant: ParticipantDefinition) => {
     return ParticipantStore.create(participant);
   },
 
   get: async (id: string) => {
     return ParticipantStore.get(id);
+  },
+
+  list: async (startIndex?: number, pageSize?: number) => {
+    return ParticipantStore.list(startIndex, pageSize);
   },
 
   update: async (id: string, participant: ParticipantUpdate) => {

--- a/libs/prm-engine/src/lib/stores/base.store.ts
+++ b/libs/prm-engine/src/lib/stores/base.store.ts
@@ -1,5 +1,12 @@
-export interface BaseStore<TDefinition, TEntity, TPartialUpdateDefinition> {
+export interface BaseStore<
+  TDefinition,
+  TEntity,
+  TPartialUpdateDefinition,
+  TEntityListItem,
+> {
+  count: () => Promise<number>;
   create: (entity: TDefinition) => Promise<TEntity>;
   get: (id: string) => Promise<TEntity | null>;
+  list: (startIndex?: number, pageSize?: number) => Promise<TEntityListItem[]>;
   update: (id: string, entity: TPartialUpdateDefinition) => Promise<TEntity>;
 }

--- a/libs/prm-engine/src/lib/stores/base.store.ts
+++ b/libs/prm-engine/src/lib/stores/base.store.ts
@@ -1,3 +1,5 @@
+import { Pagination } from '@nrcno/core-models';
+
 export interface BaseStore<
   TDefinition,
   TEntity,
@@ -7,6 +9,6 @@ export interface BaseStore<
   count: () => Promise<number>;
   create: (entity: TDefinition) => Promise<TEntity>;
   get: (id: string) => Promise<TEntity | null>;
-  list: (startIndex?: number, pageSize?: number) => Promise<TEntityListItem[]>;
+  list: (pagination: Pagination) => Promise<TEntityListItem[]>;
   update: (id: string, entity: TPartialUpdateDefinition) => Promise<TEntity>;
 }

--- a/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
@@ -176,7 +176,7 @@ describe('Participant store', () => {
         displacementStatus: participant.displacementStatus,
         primaryIdentificationType: primaryIdentification.identificationType,
         primaryIdentificationNumber: primaryIdentification.identificationNumber,
-        nationality: participant.nationalities[0].isoCode,
+        nationality: participant.nationalities[0],
         email: participant.contactDetails.emails[0].value,
         phone: participant.contactDetails.phones[0].value,
       });

--- a/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
@@ -39,6 +39,13 @@ describe('Participant store', () => {
     getDb(undefined, (global as any).db);
   });
 
+  afterEach(async () => {
+    // TODO: implement cleaning up the database after each test in a better way.
+    // Either move this to a global jest test setup or use a transaction for each test
+    const db = getDb();
+    await db.raw('TRUNCATE TABLE participants CASCADE');
+  });
+
   describe('create', () => {
     test('should throw an AlredyExistsError when creating a participant that already exists', async () => {
       const participantDefinition = ParticipantGenerator.generateDefinition();
@@ -114,6 +121,106 @@ describe('Participant store', () => {
       const participant = await ParticipantStore.get('non-existing-id');
 
       expect(participant).toBeNull();
+    });
+  });
+
+  describe('count', () => {
+    beforeAll(() => {
+      (ulid as jest.Mock).mockImplementation(() =>
+        jest.requireActual('ulidx').ulid(),
+      );
+      (v4 as jest.Mock).mockImplementation(() =>
+        jest.requireActual('uuid').v4(),
+      );
+    });
+    test('should return the number of participants', async () => {
+      const participantDefinition = ParticipantGenerator.generateDefinition();
+
+      await ParticipantStore.create(participantDefinition);
+
+      const count = await ParticipantStore.count();
+
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('list', () => {
+    beforeAll(() => {
+      (ulid as jest.Mock).mockImplementation(() =>
+        jest.requireActual('ulidx').ulid(),
+      );
+      (v4 as jest.Mock).mockImplementation(() =>
+        jest.requireActual('uuid').v4(),
+      );
+    });
+
+    test('should return a list of participants', async () => {
+      const primaryIdentification = IdentificationGenerator.generateDefinition({
+        isPrimary: true,
+      });
+      const participantDefinition = ParticipantGenerator.generateDefinition({
+        identification: [primaryIdentification],
+      });
+      const participant = await ParticipantStore.create(participantDefinition);
+
+      const participants = await ParticipantStore.list();
+
+      expect(participants).toBeDefined();
+      expect(participants).toHaveLength(1);
+      expect(participants[0]).toEqual({
+        id: participant.id,
+        firstName: participant.firstName,
+        lastName: participant.lastName,
+        dateOfBirth: participant.dateOfBirth,
+        sex: participant.sex,
+        displacementStatus: participant.displacementStatus,
+        primaryIdentificationType: primaryIdentification.identificationType,
+        primaryIdentificationNumber: primaryIdentification.identificationNumber,
+        nationality: participant.nationalities[0].isoCode,
+        email: participant.contactDetails.emails[0].value,
+        phone: participant.contactDetails.phones[0].value,
+      });
+    });
+
+    test('should return a paginated list of participants, sorted by lastname', async () => {
+      const firstParticipantDefinition =
+        ParticipantGenerator.generateDefinition({ lastName: 'Allende' });
+      const secondParticipantDefinition =
+        ParticipantGenerator.generateDefinition({ lastName: 'Bach' });
+      const firstParticipant = await ParticipantStore.create(
+        firstParticipantDefinition,
+      );
+      await ParticipantStore.create(secondParticipantDefinition);
+
+      const participants = await ParticipantStore.list(0, 1);
+
+      expect(participants).toBeDefined();
+      expect(participants).toHaveLength(1);
+      expect(participants[0].id).toEqual(firstParticipant.id);
+    });
+
+    test('should return null for values not defined', async () => {
+      const participantDefinition = ParticipantGenerator.generateDefinition({
+        identification: [],
+        nationalities: [],
+        contactDetails: { emails: [], phones: [] },
+      });
+      const participant = await ParticipantStore.create(participantDefinition);
+
+      const participants = await ParticipantStore.list();
+
+      expect(participants).toBeDefined();
+      expect(participants).toHaveLength(1);
+      expect(participants[0]).toEqual(
+        expect.objectContaining({
+          id: participant.id,
+          primaryIdentificationType: null,
+          primaryIdentificationNumber: null,
+          nationality: null,
+          email: null,
+          phone: null,
+        }),
+      );
     });
   });
 

--- a/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
@@ -163,7 +163,10 @@ describe('Participant store', () => {
       });
       const participant = await ParticipantStore.create(participantDefinition);
 
-      const participants = await ParticipantStore.list();
+      const participants = await ParticipantStore.list({
+        startIndex: 0,
+        pageSize: 50,
+      });
 
       expect(participants).toBeDefined();
       expect(participants).toHaveLength(1);
@@ -192,7 +195,10 @@ describe('Participant store', () => {
       );
       await ParticipantStore.create(secondParticipantDefinition);
 
-      const participants = await ParticipantStore.list(0, 1);
+      const participants = await ParticipantStore.list({
+        startIndex: 0,
+        pageSize: 1,
+      });
 
       expect(participants).toBeDefined();
       expect(participants).toHaveLength(1);
@@ -207,7 +213,10 @@ describe('Participant store', () => {
       });
       const participant = await ParticipantStore.create(participantDefinition);
 
-      const participants = await ParticipantStore.list();
+      const participants = await ParticipantStore.list({
+        startIndex: 0,
+        pageSize: 50,
+      });
 
       expect(participants).toBeDefined();
       expect(participants).toHaveLength(1);

--- a/libs/prm-engine/src/lib/stores/participant.store.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.ts
@@ -3,6 +3,7 @@ import { ulid } from 'ulidx';
 
 import {
   ContactDetailType,
+  Pagination,
   Participant,
   ParticipantDefinition,
   ParticipantListItem,
@@ -219,10 +220,7 @@ const get = async (id: string): Promise<Participant | null> => {
   return participantResult;
 };
 
-const list = async (
-  startIndex = 0,
-  pageSize = 50,
-): Promise<ParticipantListItem[]> => {
+const list = async (pagination: Pagination): Promise<ParticipantListItem[]> => {
   const db = getDb();
 
   const participantFields = [
@@ -248,8 +246,8 @@ const list = async (
         db.raw('?', [true]),
       );
     })
-    .limit(pageSize)
-    .offset(startIndex)
+    .limit(pagination.pageSize)
+    .offset(pagination.startIndex)
     .orderBy('lastName', 'asc');
 
   const participantIds = participants.map((participant) => participant.id);


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-253
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
New GET endpoint to list participants

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Call the endpoint, expect the response to have any participants created before, ordered by last name.

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
Added some TODOs to improve our tests and make them independent. For now integration tests truncate the tables, and e2e tests don't clear the database. But that will become an issue in the future as we add more tests.

