### PR TITLE
[CORE24-38] refactor(participants): Share base participant model structure in list

### DIFF
--- a/apps/core-api-e2e/src/core-api/prm/participant.test.ts
+++ b/apps/core-api-e2e/src/core-api/prm/participant.test.ts
@@ -263,11 +263,29 @@ describe('Participants', () => {
         dateOfBirth: participantDefinition.dateOfBirth?.toISOString(),
         sex: participantDefinition.sex,
         displacementStatus: participantDefinition.displacementStatus,
-        primaryIdentificationType: primaryIdentification.identificationType,
-        primaryIdentificationNumber: primaryIdentification.identificationNumber,
-        nationality: participantDefinition.nationalities[0],
-        email: participantDefinition.contactDetails.emails[0].value,
-        phone: participantDefinition.contactDetails.phones[0].value,
+        identification: [
+          {
+            id: expect.any(String),
+            identificationType: primaryIdentification.identificationType,
+            identificationNumber: primaryIdentification.identificationNumber,
+            isPrimary: true,
+          },
+        ],
+        nationalities: [participantDefinition.nationalities[0]],
+        contactDetails: {
+          emails: [
+            {
+              value: participantDefinition.contactDetails.emails[0].value,
+              id: expect.any(String),
+            },
+          ],
+          phones: [
+            {
+              value: participantDefinition.contactDetails.phones[0].value,
+              id: expect.any(String),
+            },
+          ],
+        },
       };
 
       expect(res.status).toBe(200);

--- a/libs/models/src/lib/prm/participant.model.ts
+++ b/libs/models/src/lib/prm/participant.model.ts
@@ -273,41 +273,17 @@ export const ParticipantListItemSchema = z.object({
   dateOfBirth: z.coerce.date().nullable(),
   sex: SexSchema.nullable(),
   displacementStatus: DisplacementStatusSchema.nullable(),
-  nationalities: z
-    .array(IsoCodeSchema)
-    .refine((data) => data.length <= 1, {
-      message: 'Only main nationality',
-    })
-    .optional()
-    .default([]),
+  nationalities: z.array(IsoCodeSchema).max(1).optional().default([]),
   contactDetails: z
     .object({
-      emails: z
-        .array(ContactDetailsSchema)
-        .refine((data) => data.length <= 1, {
-          message: 'Only main email',
-        })
-        .optional()
-        .default([]),
-      phones: z
-        .array(ContactDetailsSchema)
-        .refine((data) => data.length <= 1, {
-          message: 'Only main phone number',
-        })
-        .optional()
-        .default([]),
+      emails: z.array(ContactDetailsSchema).max(1).optional().default([]),
+      phones: z.array(ContactDetailsSchema).max(1).optional().default([]),
     })
     .optional()
     .default({
       emails: [],
       phones: [],
     }),
-  identification: z
-    .array(IdentificationSchema)
-    .refine((data) => data.length <= 1, {
-      message: 'Only primary identification',
-    })
-    .optional()
-    .default([]),
+  identification: z.array(IdentificationSchema).max(1).optional().default([]),
 });
 export type ParticipantListItem = z.infer<typeof ParticipantListItemSchema>;

--- a/libs/models/src/lib/prm/participant.model.ts
+++ b/libs/models/src/lib/prm/participant.model.ts
@@ -273,10 +273,41 @@ export const ParticipantListItemSchema = z.object({
   dateOfBirth: z.coerce.date().nullable(),
   sex: SexSchema.nullable(),
   displacementStatus: DisplacementStatusSchema.nullable(),
-  primaryIdentificationType: IdentificationTypeSchema.nullable(),
-  primaryIdentificationNumber: z.string().nullable(),
-  nationality: IsoCodeSchema.nullable(),
-  email: z.string().nullable(),
-  phone: z.string().nullable(),
+  nationalities: z
+    .array(IsoCodeSchema)
+    .refine((data) => data.length <= 1, {
+      message: 'Nationalities can have at most one element',
+    })
+    .optional()
+    .default([]),
+  contactDetails: z
+    .object({
+      emails: z
+        .array(ContactDetailsSchema)
+        .refine((data) => data.length <= 1, {
+          message: 'Emails can have at most one element',
+        })
+        .optional()
+        .default([]),
+      phones: z
+        .array(ContactDetailsSchema)
+        .refine((data) => data.length <= 1, {
+          message: 'Phones can have at most one element',
+        })
+        .optional()
+        .default([]),
+    })
+    .optional()
+    .default({
+      emails: [],
+      phones: [],
+    }),
+  identification: z
+    .array(IdentificationSchema)
+    .refine((data) => data.length <= 1, {
+      message: 'Identification can have at most one element',
+    })
+    .optional()
+    .default([]),
 });
 export type ParticipantListItem = z.infer<typeof ParticipantListItemSchema>;

--- a/libs/models/src/lib/prm/participant.model.ts
+++ b/libs/models/src/lib/prm/participant.model.ts
@@ -276,7 +276,7 @@ export const ParticipantListItemSchema = z.object({
   nationalities: z
     .array(IsoCodeSchema)
     .refine((data) => data.length <= 1, {
-      message: 'Nationalities can have at most one element',
+      message: 'Only main nationality',
     })
     .optional()
     .default([]),
@@ -285,14 +285,14 @@ export const ParticipantListItemSchema = z.object({
       emails: z
         .array(ContactDetailsSchema)
         .refine((data) => data.length <= 1, {
-          message: 'Emails can have at most one element',
+          message: 'Only main email',
         })
         .optional()
         .default([]),
       phones: z
         .array(ContactDetailsSchema)
         .refine((data) => data.length <= 1, {
-          message: 'Phones can have at most one element',
+          message: 'Only main phone number',
         })
         .optional()
         .default([]),
@@ -305,7 +305,7 @@ export const ParticipantListItemSchema = z.object({
   identification: z
     .array(IdentificationSchema)
     .refine((data) => data.length <= 1, {
-      message: 'Identification can have at most one element',
+      message: 'Only primary identification',
     })
     .optional()
     .default([]),

--- a/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
@@ -177,11 +177,12 @@ describe('Participant store', () => {
         dateOfBirth: participant.dateOfBirth,
         sex: participant.sex,
         displacementStatus: participant.displacementStatus,
-        primaryIdentificationType: primaryIdentification.identificationType,
-        primaryIdentificationNumber: primaryIdentification.identificationNumber,
-        nationality: participant.nationalities[0],
-        email: participant.contactDetails.emails[0].value,
-        phone: participant.contactDetails.phones[0].value,
+        identification: participant.identification,
+        nationalities: [participant.nationalities[0]],
+        contactDetails: {
+          emails: [participant.contactDetails.emails[0]],
+          phones: [participant.contactDetails.phones[0]],
+        },
       });
     });
 
@@ -203,33 +204,6 @@ describe('Participant store', () => {
       expect(participants).toBeDefined();
       expect(participants).toHaveLength(1);
       expect(participants[0].id).toEqual(firstParticipant.id);
-    });
-
-    test('should return null for values not defined', async () => {
-      const participantDefinition = ParticipantGenerator.generateDefinition({
-        identification: [],
-        nationalities: [],
-        contactDetails: { emails: [], phones: [] },
-      });
-      const participant = await ParticipantStore.create(participantDefinition);
-
-      const participants = await ParticipantStore.list({
-        startIndex: 0,
-        pageSize: 50,
-      });
-
-      expect(participants).toBeDefined();
-      expect(participants).toHaveLength(1);
-      expect(participants[0]).toEqual(
-        expect.objectContaining({
-          id: participant.id,
-          primaryIdentificationType: null,
-          primaryIdentificationNumber: null,
-          nationality: null,
-          email: null,
-          phone: null,
-        }),
-      );
     });
   });
 

--- a/libs/test-utils/src/lib/prm/identification.generator.ts
+++ b/libs/test-utils/src/lib/prm/identification.generator.ts
@@ -4,7 +4,6 @@ import {
   IdentificationDefinition,
   Identification,
   IdentificationType,
-  ParticipantListItem,
 } from '@nrcno/core-models';
 
 import { BaseTestEntityGenerator } from '../base-test-entity-generator';
@@ -31,28 +30,12 @@ const generateEntity = (
   };
 };
 
-type IdentificationListItem = Pick<
-  ParticipantListItem,
-  'primaryIdentificationType'
-> &
-  Pick<ParticipantListItem, 'primaryIdentificationNumber'>;
-const generateListItem = (
-  overrides?: Partial<IdentificationListItem>,
-): IdentificationListItem => {
-  const identification = generateEntity();
-  return {
-    primaryIdentificationType: identification.identificationType,
-    primaryIdentificationNumber: identification.identificationNumber,
-    ...overrides,
-  };
-};
-
 export const IdentificationGenerator: BaseTestEntityGenerator<
   IdentificationDefinition,
   Identification,
-  IdentificationListItem
+  Identification
 > = {
   generateDefinition,
   generateEntity,
-  generateListItem,
+  generateListItem: generateEntity,
 };

--- a/libs/test-utils/src/lib/prm/participant.generator.ts
+++ b/libs/test-utils/src/lib/prm/participant.generator.ts
@@ -126,10 +126,12 @@ const generateListItem = (
     dateOfBirth: faker.date.past(),
     sex: faker.helpers.enumValue(Sex),
     displacementStatus: faker.helpers.enumValue(DisplacementStatus),
-    nationality: faker.helpers.arrayElement(['en', 'es', 'fr', 'ar']),
-    email: faker.internet.email(),
-    phone: faker.phone.number(),
-    ...IdentificationGenerator.generateListItem(),
+    nationalities: [faker.helpers.arrayElement(['en', 'es', 'fr', 'ar'])],
+    contactDetails: {
+      emails: [{ value: faker.internet.email(), id: faker.string.uuid() }],
+      phones: [{ value: faker.phone.number(), id: faker.string.uuid() }],
+    },
+    identification: [IdentificationGenerator.generateListItem()],
     ...overrides,
   };
 };


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-38
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Changed the Participant items in the list to be a subset of the same model defined for the full entity.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Call GET /participants and expect the data structure to be the same as the GET/participant/:id endpoint (just with less fields)

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
