### PR TITLE
[CORE24-228] fix(e2e): Changed waiting for db to be ready strategy

### DIFF
--- a/apps/core-api-e2e/src/support/global-setup.ts
+++ b/apps/core-api-e2e/src/support/global-setup.ts
@@ -19,7 +19,10 @@ module.exports = async function () {
     composeFilePath,
     composeFile,
   )
-    .withWaitStrategy('db', Wait.forHealthCheck())
+    .withWaitStrategy(
+      'db',
+      Wait.forLogMessage('database system is ready to accept connections'),
+    )
     .withStartupTimeout(120 * 1000)
     .up();
 


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-228
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Changed the strategy when waiting for the db to be ready. Before it was relying on a health check, but aparently the db can be healthy but not yet accepting connections. So changed to the specific log entry that Postgresql sends when it is.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
I ran the tests locally several times without issues. Monitor the tests running in CI and not failing sporadically anymore

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
