### PR TITLE
[CORE24-324] perf(participants): Added indexes on lastName and dateOfBirth for sorting

### DIFF
--- a/libs/db/migrations/20240529125552_create-participant-indexes-for-sorting.ts
+++ b/libs/db/migrations/20240529125552_create-participant-indexes-for-sorting.ts
@@ -3,13 +3,11 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.table('participants', (table) => {
     table.index('last_name');
-    table.index('date_of_birth');
   });
 }
 
 export async function down(knex: Knex): Promise<void> {
   await knex.schema.table('participants', (table) => {
     table.dropIndex('last_name');
-    table.dropIndex('date_of_birth');
   });
 }

--- a/libs/db/migrations/20240529125552_create-participant-indexes-for-sorting.ts
+++ b/libs/db/migrations/20240529125552_create-participant-indexes-for-sorting.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('participants', (table) => {
+    table.index('last_name');
+    table.index('date_of_birth');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('participants', (table) => {
+    table.dropIndex('last_name');
+    table.dropIndex('date_of_birth');
+  });
+}


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-324
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Migration to add indexes to the participants table in 2 columns:
`lastName` -> since it's the default sorting criteria
`dateOfBirth`

At this point I didn't add any other indexes for the following reasons:
- Evaluated aggregation functions, and they should be fine as the main grouping happens on `participantId`, which is already indexed for being a foreign key.
- For filtering, since we are still to improve the searching process, adding indexes now may be too early.
- Low cardinality columns. We have several columns that can take only a few possible values, and for which indexes won't likely provide much value, at least yet.
- For `participants.firstName` I assumed that sorting will likely only happen when the result set is filtered and rather small (as otherwise is not a useful way of sorting), or if having sorting on more than one column. So for now I think it's better to leave without an index. It can also help to run performance tests and compare result times against sorting, e.g., by lastName.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
When adding a lot of participants, sorting/filtering by `lastName` or `dateOfBirth` should be faster. 

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
Monitor query performance.
