### PR TITLE
[CORE24-361] fix(ci): Moved migrations for integration tests to global setup

### DIFF
--- a/shared/jest.db-setup.ts
+++ b/shared/jest.db-setup.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import { Knex } from 'knex';
 
 import { getDb } from '@nrcno/core-db';
@@ -13,13 +12,6 @@ beforeAll(async () => {
     database: process.env.DB_NAME,
   };
   db = getDb(config);
-  await db.migrate.latest({
-    loadExtensions: ['.js'],
-  });
-  await db.seed.run({
-    loadExtensions: ['.js'],
-    directory: path.join(db.client.config.seeds.directory, 'common'),
-  });
 
   (global as any).db = db;
 });

--- a/shared/jest.integration-tests-setup.ts
+++ b/shared/jest.integration-tests-setup.ts
@@ -1,7 +1,10 @@
 import { config as dotenvConfig } from 'dotenv';
+import * as path from 'path';
 import { DockerComposeEnvironment, Wait } from 'testcontainers';
 import { registerTsProject } from '@nx/js/src/internal';
 const cleanupRegisteredPaths = registerTsProject('./tsconfig.base.json');
+
+import { getDb } from '@nrcno/core-db';
 
 export default async function () {
   // Start services that the app needs to run (e.g. database, docker-compose, etc.).
@@ -20,6 +23,21 @@ export default async function () {
     .withWaitStrategy('db', Wait.forHealthCheck())
     .withStartupTimeout(120 * 1000)
     .up();
+
+  const config = {
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  };
+  const db = getDb(config);
+  await db.migrate.latest({
+    loadExtensions: ['.js'],
+  });
+  await db.seed.run({
+    loadExtensions: ['.js'],
+    directory: path.join(db.client.config.seeds.directory, 'common'),
+  });
 
   // Pass the environment to global teardown
   (global as any).__ENVIRONMENT__ = environment;


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-361
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
When adding extra integration test files, I moved the database initialisation to a different setup file, since the global setup doesn't share a context with the test files. But the new setup file was being executed before each test file, and I understand running migrations in parallel was causing this issue.
So now moved running migrations and seeds to the global setup, while still having the db setup initialising a new connection for each test file.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Expect CI build to pass.

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
