### PR TITLE
[CORE24-368] fix(individuals): Handle validation error in data access layer + truncate data having invalid values

### DIFF
--- a/libs/db/migrations/20240612130245_truncate-participants-table.ts
+++ b/libs/db/migrations/20240612130245_truncate-participants-table.ts
@@ -1,0 +1,11 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw('TRUNCATE TABLE participants CASCADE');
+  await knex.raw('TRUNCATE TABLE persons CASCADE');
+  await knex.raw('TRUNCATE TABLE entities CASCADE');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Can't be undone, but since we only have test data in DEV, this is not a problem
+}


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-368
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Added a migration truncating the individual tables, since they contain invalid data (from before we added data validation).
Added handling for validation error in the data access layer, which at the moment was causing 400 error responses (since we use zod for validation, and we catch zod errors and treat them as bad requests). Now a general error is re-thrown, which should end up in a 500 Internal Server error.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Go to individual list and expect it to be empty. Start adding data again and it should show.

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
