### PR TITLE
[CORE24-362] fix(individuals): removed isPrimary from identifications

### DIFF
--- a/apps/core-api-e2e/src/core-api/prm/participant.test.ts
+++ b/apps/core-api-e2e/src/core-api/prm/participant.test.ts
@@ -221,12 +221,7 @@ describe('Participants', () => {
   });
 
   describe('GET /api/prm/participants', () => {
-    const primaryIdentification = IdentificationGenerator.generateDefinition({
-      isPrimary: true,
-    });
-    const participantDefinition = ParticipantGenerator.generateDefinition({
-      identification: [primaryIdentification],
-    });
+    const participantDefinition = ParticipantGenerator.generateDefinition();
     let participantId: string;
     beforeAll(async () => {
       const res = await axiosInstance.post(
@@ -249,9 +244,10 @@ describe('Participants', () => {
         identification: [
           {
             id: expect.any(String),
-            identificationType: primaryIdentification.identificationType,
-            identificationNumber: primaryIdentification.identificationNumber,
-            isPrimary: true,
+            identificationType:
+              participantDefinition.identification[0].identificationType,
+            identificationNumber:
+              participantDefinition.identification[0].identificationNumber,
           },
         ],
         nationalities: [participantDefinition.nationalities[0]],

--- a/libs/db/migrations/20240613094424_drop-identification-primary-column.ts
+++ b/libs/db/migrations/20240613094424_drop-identification-primary-column.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('participant_identifications', (table) => {
+    table.dropColumn('is_primary');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('participant_identifications', (table) => {
+    table.boolean('is_primary').notNullable().defaultTo(false);
+  });
+}

--- a/libs/models/src/lib/prm/participant.model.test.ts
+++ b/libs/models/src/lib/prm/participant.model.test.ts
@@ -37,7 +37,6 @@ describe('ParticipantSchema', () => {
           id: faker.string.uuid(),
           identificationType: 'unhcr_id',
           identificationNumber: '1234567890',
-          isPrimary: true,
         },
       ],
     };
@@ -58,23 +57,8 @@ describe('ParticipantSchema', () => {
       consentReferral: true,
       languages: [],
       nationalities: [],
-      contactDetails: [
-        {
-          contactDetailType: 'email',
-          value: 'john.doe@example.com',
-        },
-        {
-          contactDetailType: 'phone_number',
-          value: '1234567890',
-        },
-      ],
-      identification: [
-        {
-          identificationType: 'unhcr_id',
-          identificationNumber: '1234567890',
-          isPrimary: true,
-        },
-      ],
+      contactDetails: [],
+      identification: [],
     };
 
     const result = ParticipantSchema.safeParse(participant);
@@ -110,7 +94,6 @@ describe('ParticipantDefinitionSchema', () => {
         {
           identificationType: 'unhcr_id',
           identificationNumber: '1234567890',
-          isPrimary: true,
         },
       ],
     };
@@ -130,23 +113,8 @@ describe('ParticipantDefinitionSchema', () => {
       consentReferral: true,
       languages: [],
       nationalities: [],
-      contactDetails: [
-        {
-          contactDetailType: 'email',
-          value: 'john.doe@example.com',
-        },
-        {
-          contactDetailType: 'phone_number',
-          value: '1234567890',
-        },
-      ],
-      identification: [
-        {
-          identificationType: 'unhcr_id',
-          identificationNumber: '1234567890',
-          isPrimary: true,
-        },
-      ],
+      contactDetails: [],
+      identification: [],
     };
 
     const result = ParticipantDefinitionSchema.safeParse(participantDefinition);

--- a/libs/models/src/lib/prm/participant.model.ts
+++ b/libs/models/src/lib/prm/participant.model.ts
@@ -106,7 +106,6 @@ export type ContactDetails = z.infer<typeof EmailContactDetailsSchema>;
 const IdentificationDefinitionSchema = z.object({
   identificationType: IdentificationTypeSchema,
   identificationNumber: z.string().max(40),
-  isPrimary: z.boolean().optional().default(false),
 });
 export type IdentificationDefinition = z.infer<
   typeof IdentificationDefinitionSchema

--- a/libs/prm-components/src/lib/config/participant.ts
+++ b/libs/prm-components/src/lib/config/participant.ts
@@ -159,12 +159,6 @@ export const participantConfig: EntityUIConfigLoader = (staticData) => ({
                 component: Component.TextInput,
                 label: 'Identification Number',
               },
-              {
-                path: ['isPrimary'],
-                dataType: DataType.String,
-                component: Component.Checkbox,
-                label: 'Is Primary',
-              },
             ],
           },
           {

--- a/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/participant.store.integration.test.ts
@@ -177,12 +177,7 @@ describe('Participant store', () => {
     });
 
     test('should return a list of participants', async () => {
-      const primaryIdentification = IdentificationGenerator.generateDefinition({
-        isPrimary: true,
-      });
-      const participantDefinition = ParticipantGenerator.generateDefinition({
-        identification: [primaryIdentification],
-      });
+      const participantDefinition = ParticipantGenerator.generateDefinition();
       const participant = await ParticipantStore.create(participantDefinition);
 
       const participants = await ParticipantStore.list({
@@ -199,7 +194,7 @@ describe('Participant store', () => {
         dateOfBirth: participant.dateOfBirth,
         sex: participant.sex,
         displacementStatus: participant.displacementStatus,
-        identification: participant.identification,
+        identification: [participant.identification[0]],
         nationalities: [participant.nationalities[0]],
         contactDetails: {
           emails: [participant.contactDetails.emails[0]],
@@ -296,12 +291,6 @@ describe('Participant store', () => {
             {
               identificationNumber: '456',
               identificationType: IdentificationType.NationalId,
-              isPrimary: true,
-            },
-            {
-              identificationNumber: '999',
-              identificationType: IdentificationType.NationalId,
-              isPrimary: false,
             },
           ],
         });
@@ -311,12 +300,6 @@ describe('Participant store', () => {
             {
               identificationNumber: '123',
               identificationType: IdentificationType.NationalId,
-              isPrimary: true,
-            },
-            {
-              identificationNumber: '111',
-              identificationType: IdentificationType.NationalId,
-              isPrimary: false,
             },
           ],
         });
@@ -576,12 +559,10 @@ describe('Participant store', () => {
           {
             identificationNumber: '123',
             identificationType: IdentificationType.NationalId,
-            isPrimary: true,
           },
           {
             identificationNumber: '456',
             identificationType: IdentificationType.NationalId,
-            isPrimary: false,
           },
         ],
       });
@@ -592,12 +573,10 @@ describe('Participant store', () => {
             {
               identificationNumber: '789',
               identificationType: IdentificationType.NationalId,
-              isPrimary: true,
             },
             {
               identificationNumber: '012',
               identificationType: IdentificationType.NationalId,
-              isPrimary: false,
             },
           ],
         }),

--- a/libs/test-utils/src/lib/prm/identification.generator.ts
+++ b/libs/test-utils/src/lib/prm/identification.generator.ts
@@ -14,7 +14,6 @@ const generateDefinition = (
   return {
     identificationType: faker.helpers.enumValue(IdentificationType),
     identificationNumber: faker.string.alphanumeric(10),
-    isPrimary: faker.datatype.boolean(),
     ...overrides,
   };
 };


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-362
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Removed `is_primary` property from `participant_identifications` table and from models.
Updated list queries to consider the creation time instead.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Is primary checkbox for identifications should not exist anymore in forms.
No further functional changes, listing individuals should continue working the same.

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
