### PR TITLE
[CORE24-288] fix(individuals): Removed unused isMinor and Age filters from UI

### DIFF
--- a/libs/prm-components/src/lib/config/participant.ts
+++ b/libs/prm-components/src/lib/config/participant.ts
@@ -377,24 +377,6 @@ export const participantConfig: EntityUIConfigLoader = (staticData) => ({
         label: 'Date of Birth - End',
       },
       {
-        path: ['ageMin'],
-        dataType: DataType.Number,
-        component: Component.TextInput,
-        label: 'Age - Start',
-      },
-      {
-        path: ['ageMax'],
-        dataType: DataType.Number,
-        component: Component.TextInput,
-        label: 'Age - End',
-      },
-      {
-        path: ['isMinor'],
-        dataType: DataType.Boolean,
-        component: Component.Checkbox,
-        label: 'Is a minor',
-      },
-      {
         path: ['nationalities'],
         dataType: DataType.String,
         component: Component.Select,


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-288
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
We agreed with Fix that for MVP the filtering will only be by `dateOfBirth`, so the backend currently doesn't support filtering for calculated fields based on it. So removing them from the UI for consistency.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Go to search, expect `is minor` and `age` fields to not be present anymore.

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
