### PR TITLE
[CORE24-430] fix(individuals): Define sorting in code prior to query

### DIFF
--- a/libs/prm-engine/src/lib/stores/individual.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/individual.store.integration.test.ts
@@ -220,6 +220,34 @@ describe('Individual store', () => {
       expect(individuals[0].id).toEqual(firstIndividual.id);
     });
 
+    test('should return a paginated list of individuals, sorted by firstname descending', async () => {
+      const firstIndividualDefinition = IndividualGenerator.generateDefinition({
+        firstName: 'Isabel',
+      });
+      const secondIndividualDefinition = IndividualGenerator.generateDefinition(
+        { firstName: 'Richard' },
+      );
+      await IndividualStore.create(firstIndividualDefinition);
+      const secondIndividual = await IndividualStore.create(
+        secondIndividualDefinition,
+      );
+
+      const individuals = await IndividualStore.list(
+        {
+          startIndex: 0,
+          pageSize: 1,
+        },
+        {
+          sort: 'firstName',
+          direction: SortingDirection.Desc,
+        },
+      );
+
+      expect(individuals).toBeDefined();
+      expect(individuals).toHaveLength(1);
+      expect(individuals[0].id).toEqual(secondIndividual.id);
+    });
+
     test('should return a paginated list of individuals, sorted by nationality descending', async () => {
       const firstIndividualDefinition = IndividualGenerator.generateDefinition({
         nationalities: ['ALA'],


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-430
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
We had defined the query ordering in SQL, but that was introducing some issues with the validation of fields. (First issue was actually considering the column name as a string)
So moved that logic to TS, and directly send the calculated ordering field to the query.
Added an additional test for basic details, other than default sorting.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Sorting should work fine now for all fields.

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
