### PR TITLE
[CORE24-414] feat(households): Get basic household data from DB

### DIFF
--- a/libs/models/src/lib/prm/household.model.ts
+++ b/libs/models/src/lib/prm/household.model.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { IsoCodeSchema } from './common';
 import {
   IndividualDefinitionSchema,
   IndividualSchema,
@@ -30,9 +29,9 @@ const HouseholdIndividualDefinitionSchema = IndividualDefinitionSchema.pick({
 });
 
 export const HouseholdDefinitionSchema = z.object({
-  headType: HeadOfHouseholdTypeSchema.optional(),
-  sizeOverride: z.number().int().optional(),
-  individuals: z.array(HouseholdIndividualDefinitionSchema),
+  headType: HeadOfHouseholdTypeSchema.optional().nullable(),
+  sizeOverride: z.number().int().optional().nullable(),
+  individuals: z.array(HouseholdIndividualDefinitionSchema).default([]), // TODO: remove default once enforcing head of household
 });
 export type HouseholdDefinition = z.infer<typeof HouseholdDefinitionSchema>;
 
@@ -42,8 +41,6 @@ const HouseholdIndividualSchema = HouseholdIndividualDefinitionSchema.merge(
 
 export const HouseholdSchema = HouseholdDefinitionSchema.extend({
   id: z.string().ulid(),
-  headId: z.string().ulid().optional(), // TODO: remove optional once enforcing head of household
-  headNationality: IsoCodeSchema.optional(),
-  individuals: z.array(HouseholdIndividualSchema),
+  individuals: z.array(HouseholdIndividualSchema).default([]), // TODO: remove default once enforcing head of household
 });
 export type Household = z.infer<typeof HouseholdSchema>;

--- a/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
@@ -1,36 +1,9 @@
-import { ulid } from 'ulidx';
-import { v4 } from 'uuid';
-import { faker } from '@faker-js/faker';
-
 import { HouseholdGenerator } from '@nrcno/core-test-utils';
 import { getDb } from '@nrcno/core-db';
 
 import { HouseholdStore } from './household.store';
 
-jest.mock('ulidx', () => {
-  const realUlid = jest.requireActual('ulidx').ulid;
-  return {
-    ulid: jest.fn().mockImplementation(() => realUlid()),
-  };
-});
-
-jest.mock('uuid', () => {
-  const realUuid = jest.requireActual('uuid').v4;
-  return {
-    v4: jest.fn().mockImplementation(() => realUuid()),
-  };
-});
-
-function generateMockUlid() {
-  const chars = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
-  let mockUlid = '';
-  for (let i = 0; i < 26; i++) {
-    mockUlid += chars[Math.floor(Math.random() * chars.length)];
-  }
-  return mockUlid;
-}
-
-describe.skip('Household store', () => {
+describe('Household store', () => {
   beforeAll(async () => {
     getDb(undefined, (global as any).db);
   });
@@ -45,20 +18,11 @@ describe.skip('Household store', () => {
   describe('create', () => {
     test('should create and get a household', async () => {
       const householdDefinition = HouseholdGenerator.generateDefinition();
-      const householdId = generateMockUlid();
-      const contactDetailsIdPhone = faker.string.uuid();
-      const identificationId = faker.string.uuid();
-      const expectedHousehold = HouseholdGenerator.generateEntity({
+      const expectedHousehold = {
         ...householdDefinition,
-        id: householdId,
+        id: expect.any(String),
         individuals: [],
-      });
-
-      (ulid as jest.Mock).mockReturnValueOnce(householdId);
-
-      (v4 as jest.Mock)
-        .mockReturnValueOnce(contactDetailsIdPhone)
-        .mockReturnValueOnce(identificationId);
+      };
 
       const createdHousehold = await HouseholdStore.create(householdDefinition);
 
@@ -68,6 +32,14 @@ describe.skip('Household store', () => {
 
       expect(household).toBeDefined();
       expect(household).toEqual(expectedHousehold);
+    });
+  });
+
+  describe('get', () => {
+    test('should return null if household id does not exist', async () => {
+      const household = await HouseholdStore.get('non-existing-id');
+
+      expect(household).toBeNull();
     });
   });
 });

--- a/libs/test-utils/src/lib/prm/household.generator.ts
+++ b/libs/test-utils/src/lib/prm/household.generator.ts
@@ -14,7 +14,7 @@ const generateDefinition = (
   overrides?: Partial<HouseholdDefinition>,
 ): HouseholdDefinition => {
   return {
-    sizeOverride: faker.number.int(),
+    sizeOverride: faker.number.int({ max: 100 }),
     headType: faker.helpers.enumValue(HeadOfHouseholdType),
     individuals: [],
     ...overrides,
@@ -54,7 +54,6 @@ const generateEntity = (overrides?: Partial<Household>): Household => {
         ],
       };
     }),
-    headNationality: faker.location.countryCode('alpha-3'),
     id: overrides?.id || ulid(),
   };
 };


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-414
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Data access function to get a household (only data from its own table so far)

Also removed `headId` and `headNationality` from the Household model after a discussion with Fix in the GRF spreadsheet, since both values will already be present in the individuals array, for the individual marked as head of household.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
No real way to test this at the moment, other than integration tests

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
