### PR TITLE
Core24 266 list hh

### DIFF
--- a/apps/core-api/src/controllers/prm.controller.ts
+++ b/apps/core-api/src/controllers/prm.controller.ts
@@ -10,7 +10,6 @@ import {
 import {
   EntityTypeSchema,
   EntityIdSchema,
-  getEntityDefinitionSchema,
   getEntityUpdateSchema,
   PaginatedResponse,
   EntityListItem,

--- a/apps/core-frontend/src/components/Navigation.tsx
+++ b/apps/core-frontend/src/components/Navigation.tsx
@@ -1,10 +1,11 @@
-import { HStack } from '@chakra-ui/react';
+import { VStack } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 
 export const Navigation: React.FC = () => {
   return (
-    <HStack>
+    <VStack>
       <Link to="/prm/individuals">Individuals</Link>
-    </HStack>
+      <Link to="/prm/households">Households</Link>
+    </VStack>
   );
 };

--- a/apps/core-frontend/src/routes.tsx
+++ b/apps/core-frontend/src/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, useParams } from 'react-router-dom';
 
 import { EntityDetailPage, EntityListPage } from '@nrcno/core-prm-components';
 
@@ -24,19 +24,46 @@ export const router = createBrowserRouter([
           },
           {
             path: '/prm/:entityType',
-            element: <EntityListPage />,
+            Component: () => {
+              const { entityType } = useParams();
+              return <EntityListPage key={`entity-list-${entityType}`} />;
+            },
           },
           {
             path: '/prm/:entityType/new',
-            element: <EntityDetailPage mode="create" />,
+            Component: () => {
+              const { entityType } = useParams();
+              return (
+                <EntityDetailPage
+                  key={`entity-detail-${entityType}`}
+                  mode="create"
+                />
+              );
+            },
           },
           {
             path: '/prm/:entityType/:entityId',
-            element: <EntityDetailPage mode="read" />,
+            Component: () => {
+              const { entityType, entityId } = useParams();
+              return (
+                <EntityDetailPage
+                  key={`entity-detail-${entityType}-${entityId}`}
+                  mode="read"
+                />
+              );
+            },
           },
           {
             path: '/prm/:entityType/:entityId/edit',
-            element: <EntityDetailPage mode="edit" />,
+            Component: () => {
+              const { entityType, entityId } = useParams();
+              return (
+                <EntityDetailPage
+                  key={`entity-detail-${entityType}-${entityId}`}
+                  mode="edit"
+                />
+              );
+            },
           },
           {
             path: '/users',

--- a/apps/core-frontend/src/styles.scss
+++ b/apps/core-frontend/src/styles.scss
@@ -8,5 +8,5 @@ body {
 }
 
 #react-select-portal > div {
-  z-index: var(--chakra-zIndices-dropdown);
+  z-index: var(--chakra-zIndices-tooltip);
 }

--- a/libs/models/src/lib/prm/entity.model.ts
+++ b/libs/models/src/lib/prm/entity.model.ts
@@ -33,8 +33,14 @@ import {
 } from './nationality.model';
 import {
   Household,
+  HouseholdDefaultSorting,
   HouseholdDefinition,
   HouseholdDefinitionSchema,
+  HouseholdFiltering,
+  HouseholdFilteringSchema,
+  HouseholdListItem,
+  HouseholdListItemSchema,
+  HouseholdListSortingFields,
   HouseholdSchema,
 } from './household.model';
 
@@ -54,13 +60,18 @@ export type EmptyFilter = z.infer<typeof EmptyFilterSchema>;
 
 export type Entity = Household | Individual | Language | Nationality;
 export type EntityDefinition = HouseholdDefinition | IndividualDefinition;
-export type EntityListItem = IndividualListItem | Language | Nationality;
+export type EntityListItem =
+  | IndividualListItem
+  | Language
+  | Nationality
+  | HouseholdListItem;
 export type EntityUpdate = IndividualUpdate;
 export type EntityPartialUpdate = IndividualPartialUpdate;
 export type EntityFiltering =
   | IndividualFiltering
   | LanguageFilter
   | NationalityFilter
+  | HouseholdFiltering
   | EmptyFilter;
 
 export const getEntitySchema = (entityType: EntityType) => {
@@ -102,6 +113,8 @@ export const getEntityListItemSchema = (entityType: EntityType) => {
   switch (entityType) {
     case EntityType.Individual:
       return IndividualListItemSchema;
+    case EntityType.Household:
+      return HouseholdListItemSchema;
     case EntityType.Language:
       return LanguageSchema;
     case EntityType.Nationality:
@@ -115,6 +128,8 @@ export const getEntityListSortingFields = (entityType: EntityType) => {
   switch (entityType) {
     case EntityType.Individual:
       return IndividualListSortingFields;
+    case EntityType.Household:
+      return HouseholdListSortingFields;
     case EntityType.Language:
       return LanguageSortingFields;
     case EntityType.Nationality:
@@ -128,6 +143,8 @@ export const getEntityDefaultSorting = (entityType: EntityType) => {
   switch (entityType) {
     case EntityType.Individual:
       return IndividualDefaultSorting;
+    case EntityType.Household:
+      return HouseholdDefaultSorting;
     case EntityType.Language:
       return LanguageDefaultSorting;
     case EntityType.Nationality:
@@ -141,6 +158,8 @@ export const getEntityFilteringSchema = (entityType: EntityType) => {
   switch (entityType) {
     case EntityType.Individual:
       return IndividualFilteringSchema;
+    case EntityType.Household:
+      return HouseholdFilteringSchema;
     case EntityType.Language:
       return LanguageFilterSchema;
     case EntityType.Nationality:

--- a/libs/prm-components/src/lib/components/EntityDetailForm.component.tsx
+++ b/libs/prm-components/src/lib/components/EntityDetailForm.component.tsx
@@ -141,10 +141,16 @@ export const EntityDetailForm: React.FC<Props> = ({
             )}
           </HStack>
         </Flex>
-        {config.fields &&
-          config.fields.map((field, i) => (
-            <Field key={`${id}_${field.path.join('.')}_${i}`} config={field} />
-          ))}
+        {config.fields && (
+          <Flex direction="column" gap={4}>
+            {config.fields.map((field, i) => (
+              <Field
+                key={`${id}_${field.path.join('.')}_${i}`}
+                config={field}
+              />
+            ))}
+          </Flex>
+        )}
         <Accordion
           defaultIndex={config.sections.map((_, i) => i)}
           allowMultiple

--- a/libs/prm-components/src/lib/components/Fields/NumberInput.component.tsx
+++ b/libs/prm-components/src/lib/components/Fields/NumberInput.component.tsx
@@ -1,0 +1,54 @@
+import {
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Input,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput as ChakraNumberInput,
+  NumberInputField,
+  NumberInputStepper,
+} from '@chakra-ui/react';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { DataType, FieldConfig } from '../../config';
+
+type Props = {
+  config: FieldConfig;
+};
+
+export const NumberInput: React.FC<Props> = ({ config }) => {
+  const { control } = useFormContext();
+  const { field, fieldState } = useController({
+    name: config.path.join('.'),
+    control,
+  });
+
+  const value = field.value || '';
+
+  return (
+    <FormControl isInvalid={fieldState.invalid} isRequired={config.required}>
+      <FormLabel>{config.label}</FormLabel>
+      <ChakraNumberInput
+        isInvalid={fieldState.invalid}
+        isRequired={config.required}
+        placeholder={config.placeholder}
+        {...field}
+        value={value}
+      >
+        <NumberInputField />
+        <NumberInputStepper>
+          <NumberIncrementStepper />
+          <NumberDecrementStepper />
+        </NumberInputStepper>
+      </ChakraNumberInput>
+      {config.description && (
+        <FormHelperText>{config.description}</FormHelperText>
+      )}
+      {fieldState.error && (
+        <FormErrorMessage>{fieldState.error.message}</FormErrorMessage>
+      )}
+    </FormControl>
+  );
+};

--- a/libs/prm-components/src/lib/components/Fields/index.tsx
+++ b/libs/prm-components/src/lib/components/Fields/index.tsx
@@ -8,6 +8,7 @@ import { Select } from './Select.component';
 import { TextArea } from './TextArea.component';
 import { TextInput } from './TextInput.component';
 import { Hidden } from './Hidden.component';
+import { NumberInput } from './NumberInput.component';
 
 type FieldProps = {
   config: FieldConfig | ListFieldConfig;
@@ -21,6 +22,8 @@ export const Field: React.FC<FieldProps> = ({ config }) => {
       return <Hidden config={config} />;
     case Component.TextInput:
       return <TextInput config={config} />;
+    case Component.NumberInput:
+      return <NumberInput config={config} />;
     case Component.TextArea:
       return <TextArea config={config} />;
     case Component.Select:

--- a/libs/prm-components/src/lib/config/config.types.ts
+++ b/libs/prm-components/src/lib/config/config.types.ts
@@ -8,7 +8,7 @@ export enum Component {
   Display = 'display',
   TextInput = 'text-input',
   TextArea = 'text-area',
-  // NumberInput = 'number-input',
+  NumberInput = 'number-input',
   // Range = 'range',
   Select = 'select',
   Checkbox = 'checkbox',

--- a/libs/prm-components/src/lib/config/houseHold.ts
+++ b/libs/prm-components/src/lib/config/houseHold.ts
@@ -10,7 +10,7 @@ export const householdConfig: EntityUIConfigLoader = (staticData) => ({
       {
         path: ['sizeOverride'],
         dataType: DataType.Number,
-        component: Component.TextInput,
+        component: Component.NumberInput,
         label: 'Household Size Manual',
       },
       {
@@ -23,9 +23,57 @@ export const householdConfig: EntityUIConfigLoader = (staticData) => ({
     ],
   },
   list: {
-    fields: [],
+    fields: [
+      {
+        path: ['id'],
+        title: 'ID',
+        isID: true,
+        width: 4,
+      },
+      {
+        path: ['individuals', '0', 'id'],
+        title: 'Head of Household ID',
+        width: 4,
+      },
+      {
+        path: ['headType'],
+        title: 'Type of Heading',
+        width: 4,
+      },
+      {
+        path: ['sizeOverride'],
+        title: 'Household Size Manual',
+        width: 4,
+      },
+    ],
   },
   filtering: {
-    fields: [],
+    fields: [
+      {
+        path: ['id'],
+        dataType: DataType.String,
+        component: Component.TextInput,
+        label: 'ID',
+      },
+      {
+        path: ['headType'],
+        dataType: DataType.String,
+        component: Component.Select,
+        options: optionsFromEnum(HeadOfHouseholdType),
+        label: 'Type of Heading',
+      },
+      {
+        path: ['sizeOverrideMin'],
+        dataType: DataType.Number,
+        component: Component.NumberInput,
+        label: 'Min Household Size Manual',
+      },
+      {
+        path: ['sizeOverrideMax'],
+        dataType: DataType.Number,
+        component: Component.NumberInput,
+        label: 'Max Household Size Manual',
+      },
+    ],
   },
 });

--- a/libs/prm-components/src/lib/config/index.ts
+++ b/libs/prm-components/src/lib/config/index.ts
@@ -2,6 +2,7 @@ import { EntityType } from '@nrcno/core-models';
 
 import { PrmUIConfigLoader } from './config.types';
 import { individualConfig } from './individual';
+import { householdConfig } from './household';
 
 export * from './config.types';
 
@@ -19,7 +20,7 @@ const emptyConfig = {
 
 export const configLoader: PrmUIConfigLoader = (staticData) => ({
   [EntityType.Individual]: individualConfig(staticData),
-  [EntityType.Household]: emptyConfig,
+  [EntityType.Household]: householdConfig(staticData),
   [EntityType.Language]: emptyConfig,
   [EntityType.Nationality]: emptyConfig,
 });

--- a/libs/prm-components/src/lib/hooks/useEntityListPage.hook.ts
+++ b/libs/prm-components/src/lib/hooks/useEntityListPage.hook.ts
@@ -13,10 +13,9 @@ export const useEntityListPage = (
   const { entityType, list, config } = usePrmContext();
 
   useEffect(() => {
-    if (filters != null) {
-      list.listEntities(pagination, sorting, filters);
-    }
+    list.listEntities(pagination, sorting, filters || {});
   }, [
+    entityType,
     JSON.stringify(pagination),
     JSON.stringify(sorting),
     JSON.stringify(filters),

--- a/libs/prm-components/src/lib/hooks/useEntityListPage.hook.ts
+++ b/libs/prm-components/src/lib/hooks/useEntityListPage.hook.ts
@@ -13,7 +13,9 @@ export const useEntityListPage = (
   const { entityType, list, config } = usePrmContext();
 
   useEffect(() => {
-    list.listEntities(pagination, sorting, filters || {});
+    if (filters != null) {
+      list.listEntities(pagination, sorting, filters);
+    }
   }, [
     entityType,
     JSON.stringify(pagination),

--- a/libs/prm-components/src/lib/hooks/useFilters.ts
+++ b/libs/prm-components/src/lib/hooks/useFilters.ts
@@ -45,6 +45,10 @@ export const useFilters = (): UseFilters => {
   };
 
   useEffect(() => {
+    setFilters(null);
+  }, [entityType]);
+
+  useEffect(() => {
     parseParams(searchParams);
 
     return () => {

--- a/libs/prm-components/src/lib/hooks/useSorting.hook.ts
+++ b/libs/prm-components/src/lib/hooks/useSorting.hook.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Sorting, SortingDirection } from '@nrcno/core-models';
 
 export interface UseSorting {
@@ -14,6 +14,12 @@ export const useSorting = (defaultSort: Sorting | null): UseSorting => {
       direction: SortingDirection.Asc,
     },
   );
+
+  useEffect(() => {
+    if (defaultSort) {
+      setSorting(defaultSort);
+    }
+  }, [JSON.stringify(defaultSort)]);
 
   const isCurrentSort = (field: Sorting['sort']) => {
     return sorting.sort === field;

--- a/libs/prm-components/src/lib/prm.context.tsx
+++ b/libs/prm-components/src/lib/prm.context.tsx
@@ -80,6 +80,13 @@ export const PrmProvider: React.FC<Props> = ({
   const edit = useEditEntity(client);
   const list = useListEntity(client);
 
+  React.useEffect(() => {
+    create.reset();
+    read.reset();
+    edit.reset();
+    list.reset();
+  }, [validEntityType]);
+
   const config = configLoader(
     staticData.data ?? { languages: [], nationalities: [] },
   );

--- a/libs/prm-engine/src/lib/services/household.service.ts
+++ b/libs/prm-engine/src/lib/services/household.service.ts
@@ -5,6 +5,8 @@ import {
   Household,
   HouseholdDefinition,
   HouseholdDefinitionSchema,
+  HouseholdFiltering,
+  HouseholdListItem,
 } from '@nrcno/core-models';
 
 import { HouseholdStore } from '../stores/household.store';
@@ -16,8 +18,8 @@ export class HouseholdService extends CRUDMixin<
   Household,
   any,
   any,
-  any,
-  any
+  HouseholdListItem,
+  HouseholdFiltering
 >(HouseholdDefinitionSchema as z.ZodType<HouseholdDefinition>)(
   class {
     public entityType = EntityType.Household;

--- a/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
@@ -1,6 +1,13 @@
+import { over } from 'lodash';
+
 import { HouseholdGenerator } from '@nrcno/core-test-utils';
 import { getDb } from '@nrcno/core-db';
-import { SortingDirection } from '@nrcno/core-models';
+import {
+  HeadOfHouseholdType,
+  Household,
+  HouseholdListSortingFields,
+  SortingDirection,
+} from '@nrcno/core-models';
 
 import { HouseholdStore } from './household.store';
 
@@ -87,21 +94,154 @@ describe('Household store', () => {
       });
     });
 
-    test('should return a paginated list of households, sorted by id by default', async () => {
-      const householdDefinition = HouseholdGenerator.generateDefinition();
-      const household1 = await HouseholdStore.create(householdDefinition);
-      const household2 = await HouseholdStore.create(householdDefinition);
-      const expectedFirstHouseholdId =
-        household1.id < household2.id ? household1.id : household2.id;
+    describe('sorting', () => {
+      test('should return a paginated list of households, sorted by id by default', async () => {
+        const householdDefinition = HouseholdGenerator.generateDefinition();
+        const household1 = await HouseholdStore.create(householdDefinition);
+        const household2 = await HouseholdStore.create(householdDefinition);
+        const expectedFirstHouseholdId =
+          household1.id < household2.id ? household1.id : household2.id;
 
-      const households = await HouseholdStore.list({
-        startIndex: 0,
-        pageSize: 1,
+        const households = await HouseholdStore.list({
+          startIndex: 0,
+          pageSize: 1,
+        });
+
+        expect(households).toBeDefined();
+        expect(households).toHaveLength(1);
+        expect(households[0].id).toEqual(expectedFirstHouseholdId);
       });
 
-      expect(households).toBeDefined();
-      expect(households).toHaveLength(1);
-      expect(households[0].id).toEqual(expectedFirstHouseholdId);
+      const householdListSortingFieldOverrides: Record<string, any> = {
+        id: [{}, {}],
+        headType: [
+          { headType: HeadOfHouseholdType.AdultFemale },
+          { headType: HeadOfHouseholdType.ElderlyMale },
+        ],
+        sizeOverride: [{ sizeOverride: 1 }, { sizeOverride: 2 }],
+      };
+
+      HouseholdListSortingFields.forEach((sortingField) => {
+        Object.entries(SortingDirection).forEach(
+          ([sortingDirection, sortingDirectionValue]) => {
+            test(`should return a paginated list of households, sorted by ${sortingField} ${sortingDirection}`, async () => {
+              const householdDefinition1 =
+                HouseholdGenerator.generateDefinition(
+                  householdListSortingFieldOverrides[sortingField][0],
+                );
+              const householdDefinition2 =
+                HouseholdGenerator.generateDefinition(
+                  householdListSortingFieldOverrides[sortingField][1],
+                );
+
+              const household1 =
+                await HouseholdStore.create(householdDefinition1);
+              const household2 =
+                await HouseholdStore.create(householdDefinition2);
+
+              const expectedFirstHouseholdId =
+                sortingDirectionValue === SortingDirection.Asc
+                  ? household1.id
+                  : household2.id;
+
+              const households = await HouseholdStore.list(
+                {
+                  startIndex: 0,
+                  pageSize: 1,
+                },
+                {
+                  sort: sortingField,
+                  direction: sortingDirectionValue,
+                },
+              );
+
+              expect(households).toBeDefined();
+              expect(households).toHaveLength(1);
+              expect(households[0].id).toEqual(expectedFirstHouseholdId);
+            });
+          },
+        );
+      });
+    });
+
+    describe('filtering', () => {
+      const filteringFields: (
+        | {
+            field: string;
+            overrides: Record<string, any>[];
+            filterValue: any;
+            filterKey?: never;
+          }
+        | {
+            field: string;
+            overrides: Record<string, any>[];
+            filterKey: keyof Household;
+            filterValue?: never;
+          }
+      )[] = [
+        {
+          field: 'id',
+          overrides: [{}, {}],
+          filterKey: 'id',
+        },
+        {
+          field: 'headType',
+          overrides: [
+            { headType: HeadOfHouseholdType.AdultFemale },
+            { headType: HeadOfHouseholdType.ElderlyMale },
+          ],
+          filterKey: 'headType',
+        },
+        {
+          field: 'sizeOverrideMin',
+          overrides: [{ sizeOverride: 3 }, { sizeOverride: 1 }],
+          filterValue: 2,
+        },
+        {
+          field: 'sizeOverrideMax',
+          overrides: [{ sizeOverride: 1 }, { sizeOverride: 3 }],
+          filterValue: 2,
+        },
+      ];
+
+      filteringFields.forEach((filteringField) => {
+        test(`should return a paginated list of households, filtered by ${filteringField}`, async () => {
+          const householdDefinition1 = HouseholdGenerator.generateDefinition(
+            filteringField.overrides[0],
+          );
+          const householdDefinition2 = HouseholdGenerator.generateDefinition(
+            filteringField.overrides[1],
+          );
+
+          const household1 = await HouseholdStore.create(householdDefinition1);
+          await HouseholdStore.create(householdDefinition2);
+
+          const filterValue = (() => {
+            if (filteringField.filterValue) {
+              return filteringField.filterValue;
+            }
+            if (filteringField.filterKey) {
+              return household1[filteringField.filterKey];
+            }
+            throw new Error('Filter value not provided');
+          })();
+
+          const households = await HouseholdStore.list(
+            {
+              startIndex: 0,
+              pageSize: 50,
+            },
+            undefined,
+            {
+              [filteringField.field]: filterValue,
+            },
+          );
+
+          expect(households).toBeDefined();
+          expect(households).toHaveLength(1);
+          expect(households[0].id).toEqual(household1.id);
+        });
+      });
     });
   });
 });

--- a/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
@@ -1,7 +1,31 @@
 import { HouseholdGenerator } from '@nrcno/core-test-utils';
 import { getDb } from '@nrcno/core-db';
+import { SortingDirection } from '@nrcno/core-models';
 
 import { HouseholdStore } from './household.store';
+
+jest.mock('ulidx', () => {
+  const realUlid = jest.requireActual('ulidx').ulid;
+  return {
+    ulid: jest.fn().mockImplementation(() => realUlid()),
+  };
+});
+
+jest.mock('uuid', () => {
+  const realUuid = jest.requireActual('uuid').v4;
+  return {
+    v4: jest.fn().mockImplementation(() => realUuid()),
+  };
+});
+
+function generateMockUlid() {
+  const chars = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+  let mockUlid = '';
+  for (let i = 0; i < 26; i++) {
+    mockUlid += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return mockUlid;
+}
 
 describe('Household store', () => {
   beforeAll(async () => {
@@ -15,7 +39,7 @@ describe('Household store', () => {
     await db.raw('TRUNCATE TABLE households CASCADE');
   });
 
-  describe('create', () => {
+  describe.skip('create', () => {
     test('should create and get a household', async () => {
       const householdDefinition = HouseholdGenerator.generateDefinition();
       const expectedHousehold = {
@@ -40,6 +64,44 @@ describe('Household store', () => {
       const household = await HouseholdStore.get('non-existing-id');
 
       expect(household).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    test('should return a list of households', async () => {
+      const householdDefinition = HouseholdGenerator.generateDefinition();
+      const household = await HouseholdStore.create(householdDefinition);
+
+      const households = await HouseholdStore.list({
+        startIndex: 0,
+        pageSize: 50,
+      });
+
+      expect(households).toBeDefined();
+      expect(households).toHaveLength(1);
+      expect(households[0]).toEqual({
+        id: household.id,
+        headType: household.headType,
+        sizeOverride: household.sizeOverride,
+        individuals: [],
+      });
+    });
+
+    test('should return a paginated list of households, sorted by id by default', async () => {
+      const householdDefinition = HouseholdGenerator.generateDefinition();
+      const household1 = await HouseholdStore.create(householdDefinition);
+      const household2 = await HouseholdStore.create(householdDefinition);
+      const expectedFirstHouseholdId =
+        household1.id < household2.id ? household1.id : household2.id;
+
+      const households = await HouseholdStore.list({
+        startIndex: 0,
+        pageSize: 1,
+      });
+
+      expect(households).toBeDefined();
+      expect(households).toHaveLength(1);
+      expect(households[0].id).toEqual(expectedFirstHouseholdId);
     });
   });
 });

--- a/libs/test-utils/src/lib/prm/household.generator.ts
+++ b/libs/test-utils/src/lib/prm/household.generator.ts
@@ -6,6 +6,7 @@ import {
   Household,
   HeadOfHouseholdType,
   IdentificationType,
+  HouseholdListItem,
 } from '@nrcno/core-models';
 
 import { BaseTestEntityGenerator } from '../base-test-entity-generator';
@@ -58,12 +59,21 @@ const generateEntity = (overrides?: Partial<Household>): Household => {
   };
 };
 
+const generateListItem = (): HouseholdListItem => {
+  return {
+    id: ulid(),
+    headType: faker.helpers.enumValue(HeadOfHouseholdType),
+    sizeOverride: faker.number.int(),
+    individuals: [{ id: ulid(), isHeadOfHousehold: true }],
+  };
+};
+
 export const HouseholdGenerator: BaseTestEntityGenerator<
   HouseholdDefinition,
   Household,
-  any
+  HouseholdListItem
 > = {
   generateDefinition,
   generateEntity,
-  generateListItem: () => [],
+  generateListItem,
 };


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-266
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
* List store for household, with sorting and filtering
* List ui config household
* Add list related schemas to HH model
* Filtering ui config for HH
* Add HH things to various entity utils
* Add key to routes to force rerender when changing url
* Some small styling tweaks
* Add number input field

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
* List view of households works as expected, incl. filtering and sorting
* Switching between households causes no issues (eg. no 400s, no incorrect lists showing, filters reset, sorting reset)

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
* The key in routes change was a quick fix. I think we should maybe look at a refactor of how state is managed in the frontend. As we move into relationships between entities, we may want to store multiple entity lists in state but we only support one at a time for now.
