### PR TITLE
[CORE24-548] feat(households): Endpoint to update basic details

### DIFF
--- a/apps/core-api-e2e/src/core-api/prm/household.test.ts
+++ b/apps/core-api-e2e/src/core-api/prm/household.test.ts
@@ -56,4 +56,42 @@ describe('Households', () => {
       expect(response.status).toBe(404);
     });
   });
+
+  describe('PUT /households/:id', () => {
+    let householdId: string;
+    const householdDefinition = HouseholdGenerator.generateDefinition();
+
+    beforeAll(async () => {
+      const res = await axiosInstance.post(
+        `/api/prm/households`,
+        householdDefinition,
+      );
+
+      householdId = res.data.id;
+    });
+
+    it('should update a household', async () => {
+      const updatedHousehold = {
+        ...householdDefinition,
+        sizeOverride: 5,
+      };
+
+      const res = await axiosInstance.put(
+        `/api/prm/households/${householdId}`,
+        updatedHousehold,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.data).toEqual({ ...updatedHousehold, id: householdId });
+    });
+
+    it('should return an error if the household does not exist', async () => {
+      const response = await axiosInstance.put(
+        `/api/prm/households/${ulid()}`,
+        householdDefinition,
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
 });

--- a/apps/core-api/src/controllers/prm.controller.test.ts
+++ b/apps/core-api/src/controllers/prm.controller.test.ts
@@ -29,10 +29,6 @@ const fakeIndividualWithDefaults = {
 
 const ps = {
   count: jest.fn().mockResolvedValue(0),
-  create: jest.fn().mockImplementation((entityDefinition) => ({
-    ...entityDefinition,
-    id: ulid(),
-  })),
   validateAndCreate: jest.fn().mockImplementation((entityDefinition) => ({
     ...entityDefinition,
     id: ulid(),
@@ -42,7 +38,7 @@ const ps = {
     id,
   })),
   list: jest.fn().mockResolvedValue([]),
-  update: jest.fn().mockImplementation((id, entityDefinition) => ({
+  validateAndUpdate: jest.fn().mockImplementation((id, entityDefinition) => ({
     ...entityDefinition,
     id,
   })),
@@ -340,7 +336,7 @@ describe('PRM Controller', () => {
 
         await updateEntity(req, res, next);
 
-        expect(individualService.update).toHaveBeenCalledWith(
+        expect(individualService.validateAndUpdate).toHaveBeenCalledWith(
           id,
           fakeIndividualWithDefaults,
         );
@@ -394,7 +390,7 @@ describe('PRM Controller', () => {
         const res = httpMocks.createResponse();
         const next = jest.fn();
 
-        (individualService.update as jest.Mock).mockRejectedValue(
+        (individualService.validateAndUpdate as jest.Mock).mockRejectedValue(
           new Error('Failed to update entity'),
         );
 

--- a/apps/core-api/src/controllers/prm.controller.test.ts
+++ b/apps/core-api/src/controllers/prm.controller.test.ts
@@ -29,6 +29,10 @@ const fakeIndividualWithDefaults = {
 
 const ps = {
   count: jest.fn().mockResolvedValue(0),
+  create: jest.fn().mockImplementation((entityDefinition) => ({
+    ...entityDefinition,
+    id: ulid(),
+  })),
   validateAndCreate: jest.fn().mockImplementation((entityDefinition) => ({
     ...entityDefinition,
     id: ulid(),
@@ -38,6 +42,10 @@ const ps = {
     id,
   })),
   list: jest.fn().mockResolvedValue([]),
+  update: jest.fn().mockImplementation((id, entityDefinition) => ({
+    ...entityDefinition,
+    id,
+  })),
   validateAndUpdate: jest.fn().mockImplementation((id, entityDefinition) => ({
     ...entityDefinition,
     id,
@@ -338,11 +346,11 @@ describe('PRM Controller', () => {
 
         expect(individualService.validateAndUpdate).toHaveBeenCalledWith(
           id,
-          fakeIndividualWithDefaults,
+          fakeIndividual,
         );
         expect(res.statusCode).toEqual(200);
         expect(res._getJSONData()).toEqual({
-          ...fakeIndividualWithDefaults,
+          ...fakeIndividual,
           id,
         });
       });

--- a/apps/core-api/src/controllers/prm.controller.ts
+++ b/apps/core-api/src/controllers/prm.controller.ts
@@ -10,7 +10,6 @@ import {
 import {
   EntityTypeSchema,
   EntityIdSchema,
-  getEntityUpdateSchema,
   PaginatedResponse,
   EntityListItem,
   PaginationSchema,
@@ -101,10 +100,10 @@ export const updateEntity = async (
       return;
     }
 
-    const schema = getEntityUpdateSchema(entityType.data);
-    const entityUpdate = schema.parse(req.body);
-
-    const updatedEntity = await prmService.update(entityId.data, entityUpdate);
+    const updatedEntity = await prmService.validateAndUpdate(
+      entityId.data,
+      req.body,
+    );
 
     res.status(200).json(updatedEntity);
   } catch (error) {

--- a/libs/models/src/lib/prm/entity.model.ts
+++ b/libs/models/src/lib/prm/entity.model.ts
@@ -35,7 +35,10 @@ import {
   Household,
   HouseholdDefinition,
   HouseholdDefinitionSchema,
+  HouseholdPartialUpdate,
   HouseholdSchema,
+  HouseholdUpdate,
+  HouseholdUpdateSchema,
 } from './household.model';
 
 export enum EntityType {
@@ -55,8 +58,10 @@ export type EmptyFilter = z.infer<typeof EmptyFilterSchema>;
 export type Entity = Household | Individual | Language | Nationality;
 export type EntityDefinition = HouseholdDefinition | IndividualDefinition;
 export type EntityListItem = IndividualListItem | Language | Nationality;
-export type EntityUpdate = IndividualUpdate;
-export type EntityPartialUpdate = IndividualPartialUpdate;
+export type EntityUpdate = IndividualUpdate | HouseholdUpdate;
+export type EntityPartialUpdate =
+  | IndividualPartialUpdate
+  | HouseholdPartialUpdate;
 export type EntityFiltering =
   | IndividualFiltering
   | LanguageFilter
@@ -93,6 +98,8 @@ export const getEntityUpdateSchema = (entityType: EntityType) => {
   switch (entityType) {
     case EntityType.Individual:
       return IndividualUpdateSchema;
+    case EntityType.Household:
+      return HouseholdUpdateSchema;
     default:
       throw new Error(`No update schema found for ${entityType}`);
   }

--- a/libs/models/src/lib/prm/household.model.ts
+++ b/libs/models/src/lib/prm/household.model.ts
@@ -53,7 +53,7 @@ const HouseholdIndividualUpdateSchema =
       phones: true,
     }),
   ).extend({
-    id: z.string().uuid().optional(),
+    id: z.string().ulid().optional(),
   });
 export const HouseholdUpdateSchema = HouseholdDefinitionSchema.extend({
   individuals: z.array(HouseholdIndividualUpdateSchema).default([]),

--- a/libs/models/src/lib/prm/household.model.ts
+++ b/libs/models/src/lib/prm/household.model.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   IndividualDefinitionSchema,
   IndividualSchema,
+  IndividualUpdateSchema,
 } from './individual.model';
 
 export enum HeadOfHouseholdType {
@@ -44,3 +45,24 @@ export const HouseholdSchema = HouseholdDefinitionSchema.extend({
   individuals: z.array(HouseholdIndividualSchema).default([]), // TODO: remove default once enforcing head of household
 });
 export type Household = z.infer<typeof HouseholdSchema>;
+
+const HouseholdIndividualUpdateSchema =
+  HouseholdIndividualDefinitionSchema.merge(
+    IndividualUpdateSchema.pick({
+      identification: true,
+      phones: true,
+    }),
+  ).extend({
+    id: z.string().uuid().optional(),
+  });
+export const HouseholdUpdateSchema = HouseholdDefinitionSchema.extend({
+  individuals: z.array(HouseholdIndividualUpdateSchema).default([]),
+});
+export type HouseholdUpdate = z.infer<typeof HouseholdUpdateSchema>;
+
+export const HouseholdPartialUpdateSchema = HouseholdUpdateSchema.omit({
+  individuals: true,
+});
+export type HouseholdPartialUpdate = z.infer<
+  typeof HouseholdPartialUpdateSchema
+>;

--- a/libs/prm-engine/src/lib/services/base.service.test.ts
+++ b/libs/prm-engine/src/lib/services/base.service.test.ts
@@ -1,6 +1,7 @@
 import {
   EntityType,
   IndividualDefinitionSchema,
+  IndividualUpdateSchema,
   SortingDirection,
 } from '@nrcno/core-models';
 
@@ -23,7 +24,7 @@ describe('BaseService', () => {
         any,
         any,
         any
-      >()(
+      >(IndividualUpdateSchema)(
         class {
           public entityType = EntityType.Individual;
           public store = storeMock;

--- a/libs/prm-engine/src/lib/services/household.service.test.ts
+++ b/libs/prm-engine/src/lib/services/household.service.test.ts
@@ -60,4 +60,34 @@ describe('Household service', () => {
       expect(result).toEqual(household);
     });
   });
+
+  describe('update', () => {
+    it('should call the store update method with only the basic household fields', async () => {
+      const householdUpdate = HouseholdGenerator.generateDefinition();
+      const household = HouseholdGenerator.generateEntity();
+      HouseholdStore.get = jest.fn().mockResolvedValueOnce(household);
+      HouseholdStore.update = jest.fn().mockResolvedValueOnce(household);
+
+      const result = await householdService.update(
+        household.id,
+        householdUpdate,
+      );
+
+      expect(HouseholdStore.update).toHaveBeenCalledWith(household.id, {
+        headType: householdUpdate.headType,
+        sizeOverride: householdUpdate.sizeOverride,
+      });
+      expect(result).toEqual(household);
+    });
+
+    it('should throw an error if the household does not exist', async () => {
+      HouseholdStore.get = jest.fn().mockResolvedValueOnce(null);
+
+      await expect(
+        householdService.update('12345', HouseholdGenerator.generateEntity()),
+      ).rejects.toThrow('Household with id 12345 not found');
+
+      expect(HouseholdStore.get).toHaveBeenCalledWith('12345');
+    });
+  });
 });

--- a/libs/prm-engine/src/lib/services/household.service.ts
+++ b/libs/prm-engine/src/lib/services/household.service.ts
@@ -5,7 +5,11 @@ import {
   Household,
   HouseholdDefinition,
   HouseholdDefinitionSchema,
+  HouseholdPartialUpdate,
+  HouseholdUpdate,
+  HouseholdUpdateSchema,
 } from '@nrcno/core-models';
+import { NotFoundError } from '@nrcno/core-errors';
 
 import { HouseholdStore } from '../stores/household.store';
 
@@ -14,17 +18,47 @@ import { CRUDMixin } from './base.service';
 export class HouseholdService extends CRUDMixin<
   HouseholdDefinition,
   Household,
-  any,
-  any,
+  HouseholdUpdate,
+  HouseholdPartialUpdate,
   any,
   any
->(HouseholdDefinitionSchema as z.ZodType<HouseholdDefinition>)(
+>(
+  HouseholdDefinitionSchema as z.ZodType<HouseholdDefinition>,
+  HouseholdUpdateSchema as z.ZodType<HouseholdUpdate>,
+)(
   class {
     public entityType = EntityType.Household;
     public store = HouseholdStore;
   },
 ) {
-  override mapUpdateToPartial(id: string, update: any): Promise<any> {
-    throw new Error('Method not implemented.');
+  async mapUpdateToPartial(
+    id: string,
+    update: HouseholdUpdate,
+  ): Promise<HouseholdPartialUpdate> {
+    return {
+      headType: update.headType,
+      sizeOverride: update.sizeOverride,
+    };
+  }
+
+  override async update(id: string, household: HouseholdUpdate) {
+    const existingHousehold = await this.store.get(id);
+    if (!existingHousehold) {
+      throw new NotFoundError(`Household with id ${id} not found`);
+    }
+
+    const { individuals } = household;
+    const individualsToCreate = individuals.filter(
+      (individual) => !individual.id,
+    );
+    // TODO: Create individuals passing the household id
+
+    const individualsToUpdate = individuals.filter(
+      (individual) => !!individual.id,
+    );
+    // TODO: define strategy for updating individuals
+
+    const householdDetailsUpdate = this.mapUpdateToPartial(id, household);
+    return this.store.update(id, householdDetailsUpdate);
   }
 }

--- a/libs/prm-engine/src/lib/services/household.service.ts
+++ b/libs/prm-engine/src/lib/services/household.service.ts
@@ -58,7 +58,7 @@ export class HouseholdService extends CRUDMixin<
     );
     // TODO: define strategy for updating individuals
 
-    const householdDetailsUpdate = this.mapUpdateToPartial(id, household);
+    const householdDetailsUpdate = await this.mapUpdateToPartial(id, household);
     return this.store.update(id, householdDetailsUpdate);
   }
 }

--- a/libs/prm-engine/src/lib/services/individual.service.ts
+++ b/libs/prm-engine/src/lib/services/individual.service.ts
@@ -12,6 +12,7 @@ import {
   IndividualListItem,
   IndividualPartialUpdate,
   IndividualUpdate,
+  IndividualUpdateSchema,
 } from '@nrcno/core-models';
 import { NotFoundError } from '@nrcno/core-errors';
 
@@ -28,7 +29,10 @@ export class IndividualService extends CRUDMixin<
   IndividualPartialUpdate,
   IndividualListItem,
   IndividualFiltering
->(IndividualDefinitionSchema as z.ZodType<IndividualDefinition>)(
+>(
+  IndividualDefinitionSchema as z.ZodType<IndividualDefinition>,
+  IndividualUpdateSchema as z.ZodType<IndividualUpdate>,
+)(
   class {
     public entityType = EntityType.Individual;
     public store = IndividualStore;

--- a/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
+++ b/libs/prm-engine/src/lib/stores/household.store.integration.test.ts
@@ -42,4 +42,25 @@ describe('Household store', () => {
       expect(household).toBeNull();
     });
   });
+
+  describe('update', () => {
+    test('should update a household', async () => {
+      const householdDefinition = HouseholdGenerator.generateDefinition({
+        sizeOverride: 3,
+      });
+      const createdHousehold = await HouseholdStore.create(householdDefinition);
+
+      const updatedHousehold = await HouseholdStore.update(
+        createdHousehold.id,
+        {
+          sizeOverride: 5,
+        },
+      );
+
+      expect(updatedHousehold).toEqual({
+        ...createdHousehold,
+        sizeOverride: 5,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Jira ticket: JIRA-CORE24-548
<!-- Replace # with the corresponding ticket number -->

## What have you implemented?
<!-- Please provide a brief description of the changes made in this pull request. -->
Store and service functions to update a household.
For now it only updates the specific household properties, not the individuals associated to it. For that we need to implement adding individuals to a household first.

## How to test it?
<!-- Please define a set of steps required to validate the changes. -->
Create a household, then call PUT endpoint changing its properties

## Extra/next steps
<!-- Mention any other required changes prior/after merging this PR. E.g. changes to database structure, updates in third party integrations, etc. -->
An update to a household could potentially include 3 scenarios related to the individuals that take part of it:
Removed individuals, to be tackled as part of other ticket, likely through a different endpoint.
Added individuals, I put a TODO for this, should be straightforward once we have the logic to create individuals within a household.
Updated individuals, this could be quite complicated, since the individuals here are a reduced subset of all individual properties. So we'll need to support partial updates at the service layer. Maybe discuss with the product team how valuable this bit would be. 